### PR TITLE
data-formats: use runcom's aws-cose fork and fix imports

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -16,7 +16,7 @@ serde_cbor = "0.11"
 serde_repr = "0.1.6"
 serde_tuple = "0.5"
 thiserror = "1"
-aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
+aws-nitro-enclaves-cose = {git = "https://github.com/runcom/aws-nitro-enclaves-cose", branch = "issue-17" }
 uuid = "0.8"
 
 http = "0.2"

--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -1268,9 +1268,9 @@ type COSEHeaderMapType = std::collections::HashMap<i64, serde_cbor::Value>;
 #[derive(Debug, Clone)]
 pub struct COSEHeaderMap(COSEHeaderMapType);
 
-impl From<COSEHeaderMap> for aws_nitro_enclaves_cose::sign::HeaderMap {
-    fn from(mut chm: COSEHeaderMap) -> aws_nitro_enclaves_cose::sign::HeaderMap {
-        let mut new = aws_nitro_enclaves_cose::sign::HeaderMap::new();
+impl From<COSEHeaderMap> for aws_nitro_enclaves_cose::header_map::HeaderMap {
+    fn from(mut chm: COSEHeaderMap) -> aws_nitro_enclaves_cose::header_map::HeaderMap {
+        let mut new = aws_nitro_enclaves_cose::header_map::HeaderMap::new();
         for (key, value) in chm.0.drain() {
             new.insert(serde_cbor::Value::Integer(key as i128), value);
         }


### PR DESCRIPTION
Missed it during the initial import - thanks @nullr0ute for spotting! :) 

Signed-off-by: Antonio Murdaca <runcom@linux.com>