### PR TITLE
Ensure IP Addresses get serialized accurately

### DIFF
--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -682,7 +682,12 @@ impl TryFrom<RemoteConnection> for Vec<TO2AddressEntry> {
                 RemoteAddress::IP { ip_address } => {
                     let addr = std::net::IpAddr::from_str(&ip_address)
                         .with_context(|| format!("Error parsing IP address '{}'", ip_address))?;
-                    results.push(TO2AddressEntry::new(Some(addr), None, rc.port, transport));
+                    results.push(TO2AddressEntry::new(
+                        Some(addr.into()),
+                        None,
+                        rc.port,
+                        transport,
+                    ));
                 }
                 RemoteAddress::Dns { dns_name } => {
                     results.push(TO2AddressEntry::new(


### PR DESCRIPTION
This ensures IP addresses are encoded as sequences of bytes (4 and 16
respectively), instead of the rust native serialization.

Fixes: #7
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>