### PR TITLE
Remove TLS support from servers

### DIFF
--- a/owner-onboarding-service/Cargo.toml
+++ b/owner-onboarding-service/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"
 openssl = "0.10"
-warp = { version = "0.3", features = ["tls"] }
+warp = "0.3"
 pretty_env_logger = "0.4"
 serde_cbor = "0.11"
 log = "0.4"

--- a/rendezvous-server/src/main.rs
+++ b/rendezvous-server/src/main.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use openssl::x509::X509;
 use serde::Deserialize;
 use warp::Filter;
@@ -47,8 +47,6 @@ struct Settings {
 
     // Bind information
     bind: String,
-    tls_cert_path: Option<String>,
-    tls_key_path: Option<String>,
 }
 
 const MAINTENANCE_INTERVAL: u64 = 60;
@@ -187,20 +185,8 @@ async fn main() -> Result<()> {
     let maintenance_runner =
         tokio::spawn(async move { perform_maintenance(user_data.clone()).await });
 
-    if let Some(cert_path) = settings.tls_cert_path {
-        if settings.tls_key_path.is_none() {
-            bail!("When using TLS, a key path is also required");
-        }
-        let server = server
-            .tls()
-            .cert_path(cert_path)
-            .key_path(settings.tls_key_path.unwrap())
-            .run(bind_addr);
-        let _ = tokio::join!(server, maintenance_runner);
-    } else {
-        let server = server.run(bind_addr);
-        let _ = tokio::join!(server, maintenance_runner);
-    }
+    let server = server.run(bind_addr);
+    let _ = tokio::join!(server, maintenance_runner);
 
     Ok(())
 }


### PR DESCRIPTION
This removes TLS support, so we don't depend on warp's TLS support
anymore.
Warp's TLS feature is implemented in terms of rustls, and we only want
to use openssl crypto.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>