### PR TITLE
Verify OVHeader pubkey hash

### DIFF
--- a/client-linuxapp/src/main.rs
+++ b/client-linuxapp/src/main.rs
@@ -281,6 +281,19 @@ async fn perform_to2(devcred: &DeviceCredential, urls: &[String]) -> Result<()> 
         ov_hmac
     };
 
+    // Validate the PubKeyHash
+    {
+        let header = prove_ov_hdr_payload.get_unverified_value().ov_header();
+        devcred
+            .pubkey_hash
+            .compare_data(
+                &header
+                    .get_raw_public_key()
+                    .context("Error serializing public key")?,
+            )
+            .context("Error validating manufacturer public key")?;
+    }
+
     // Get nonce6
     let nonce6: Nonce = {
         prove_ov_hdr

--- a/data-formats/src/ownershipvoucher.rs
+++ b/data-formats/src/ownershipvoucher.rs
@@ -281,6 +281,10 @@ impl OwnershipVoucherHeader {
 
         Ok(hdrinfo)
     }
+
+    pub fn get_raw_public_key(&self) -> Result<Vec<u8>> {
+        serde_cbor::to_vec(&self.public_key).map_err(|e| e.into())
+    }
 }
 
 impl TryFrom<&OwnershipVoucherHeader> for Vec<u8> {

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -351,6 +351,12 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
     let manufacturer_cert = PublicKeyBody::X509(manufacturer_cert);
     let manufacturer_pubkey = PublicKey::new(PublicKeyType::SECP256R1, manufacturer_cert)
         .context("Error creating manufacturer public key representation")?;
+    let manufacturer_pubkey_hash = Hash::new(
+        None,
+        &serde_cbor::to_vec(&manufacturer_pubkey)
+            .context("Error serializing manufacturer public key")?,
+    )
+    .context("Error hashing manufacturer public key")?;
 
     let device_cert_ca_private_key = load_private_key(&device_cert_ca_private_key_path)
         .with_context(|| {
@@ -429,7 +435,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
         device_info: device_id.to_string(),
         guid: device_guid.clone(),
         rvinfo: rendezvous_info.clone(),
-        pubkey_hash: Hash::new(None, &[]).unwrap(),
+        pubkey_hash: manufacturer_pubkey_hash,
         private_key: device_key
             .private_key_to_der()
             .context("Error serializing device private key")?,


### PR DESCRIPTION
This confirms that the manufacturer device public key as is present in
the Ownership Voucher hashes to the correct PubKeyHash as stored in the
Device Credential.

Fixes: #11
Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>