### PR TITLE
Introduce DeviceCredential abstraction

### DIFF
--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -16,7 +16,8 @@ serde_cbor = "0.11"
 serde_repr = "0.1.6"
 serde_tuple = "0.5"
 thiserror = "1"
-aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
+#aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
+aws-nitro-enclaves-cose = { git = "https://github.com/puiterwijk/aws-nitro-enclaves-cose.git", branch = "abstract-crypto" }
 uuid = "0.8"
 
 http = "0.2"

--- a/data-formats/src/constants.rs
+++ b/data-formats/src/constants.rs
@@ -28,6 +28,17 @@ impl TryFrom<HashType> for MessageDigest {
     }
 }
 
+impl HashType {
+    pub fn get_md(&self) -> MessageDigest {
+        match self {
+            HashType::Sha256 => MessageDigest::sha256(),
+            HashType::Sha384 => MessageDigest::sha384(),
+            HashType::HmacSha256 => MessageDigest::sha256(),
+            HashType::HmacSha384 => MessageDigest::sha384(),
+        }
+    }
+}
+
 impl TryFrom<MessageDigest> for HashType {
     type Error = Error;
 

--- a/data-formats/src/devicecredential/file.rs
+++ b/data-formats/src/devicecredential/file.rs
@@ -1,0 +1,72 @@
+use crate::{
+    errors::Error,
+    types::HMac,
+    types::{Guid, Hash, RendezvousInfo},
+    DeviceCredential,
+};
+
+use openssl::{pkey::PKey, sign::Signer};
+use serde::Deserialize;
+use serde_tuple::Serialize_tuple;
+
+#[derive(Debug, Serialize_tuple, Deserialize)]
+pub struct FileDeviceCredential {
+    pub active: bool,           // Active
+    pub protver: u16,           // ProtVer
+    pub hmac_secret: Vec<u8>,   // HmacSecret
+    pub device_info: String,    // DeviceInfo
+    pub guid: Guid,             // Guid
+    pub rvinfo: RendezvousInfo, // RVInfo
+    pub pubkey_hash: Hash,      // PubKeyHash
+
+    // Custom from here
+    pub private_key: Vec<u8>,
+}
+
+impl DeviceCredential for FileDeviceCredential {
+    fn is_active(&self) -> bool {
+        self.active
+    }
+
+    fn protocol_version(&self) -> u16 {
+        self.protver
+    }
+
+    fn verify_hmac(&self, data: &[u8], hmac: &HMac) -> Result<(), Error> {
+        let hmac_type = hmac.get_type();
+
+        let hmac_key = PKey::hmac(&self.hmac_secret)?;
+        let mut hmac_signer = Signer::new(hmac_type.get_md(), &hmac_key)?;
+        hmac_signer.update(&data)?;
+        let ov_hmac = hmac_signer.sign_to_vec()?;
+        let ov_hmac = HMac::new_from_data(hmac_type, ov_hmac);
+
+        if &ov_hmac != hmac {
+            Err(Error::IncorrectHash)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn device_info(&self) -> &str {
+        &self.device_info
+    }
+
+    fn device_guid(&self) -> &Guid {
+        &self.guid
+    }
+
+    fn rendezvous_info(&self) -> &RendezvousInfo {
+        &self.rvinfo
+    }
+
+    fn manufacturer_pubkey_hash(&self) -> &Hash {
+        &self.pubkey_hash
+    }
+
+    fn get_signer(
+        &self,
+    ) -> Result<Box<dyn aws_nitro_enclaves_cose::crypto::SigningPrivateKey>, Error> {
+        Ok(Box::new(PKey::private_key_from_der(&self.private_key)?))
+    }
+}

--- a/data-formats/src/devicecredential/mod.rs
+++ b/data-formats/src/devicecredential/mod.rs
@@ -1,0 +1,21 @@
+use crate::{
+    errors::Error,
+    types::{Guid, HMac, Hash, RendezvousInfo},
+};
+
+pub trait DeviceCredential: std::fmt::Debug {
+    fn is_active(&self) -> bool;
+    fn protocol_version(&self) -> u16;
+    fn verify_hmac(&self, data: &[u8], hmac: &HMac) -> Result<(), Error>;
+    fn device_info(&self) -> &str;
+    fn device_guid(&self) -> &Guid;
+    fn rendezvous_info(&self) -> &RendezvousInfo;
+    fn manufacturer_pubkey_hash(&self) -> &Hash;
+
+    fn get_signer(
+        &self,
+    ) -> Result<Box<dyn aws_nitro_enclaves_cose::crypto::SigningPrivateKey>, Error>;
+}
+
+mod file;
+pub use crate::devicecredential::file::FileDeviceCredential;

--- a/data-formats/src/lib.rs
+++ b/data-formats/src/lib.rs
@@ -7,6 +7,9 @@ pub const PROTOCOL_VERSION: u16 = (PROTOCOL_MAJOR_VERSION * 100) + PROTOCOL_MINO
 
 pub mod constants;
 
+pub mod devicecredential;
+pub use crate::devicecredential::DeviceCredential;
+
 pub mod types;
 
 pub mod enhanced_types;

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -18,7 +18,8 @@ openssl = "0.10"
 
 fdo-data-formats = { path = "../data-formats" }
 fdo-store = { path = "../store" }
-aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
+#aws-nitro-enclaves-cose = { git = "https://github.com/awslabs/aws-nitro-enclaves-cose.git", branch = "main" }
+aws-nitro-enclaves-cose = { git = "https://github.com/puiterwijk/aws-nitro-enclaves-cose.git", branch = "abstract-crypto" }
 
 # Server-side
 uuid = { version = "0.8", features = ["v4"], optional = true }

--- a/owner-onboarding-service/src/handlers.rs
+++ b/owner-onboarding-service/src/handlers.rs
@@ -278,7 +278,7 @@ pub(super) async fn prove_device(
     };
 
     let eat = token
-        .get_eat(&dev_pubkey)
+        .get_eat(dev_pubkey.as_ref())
         .map_err(Error::from_error::<messages::to2::ProveDevice, _>)?;
 
     let eat_payload: TO2ProveDevicePayload = match eat

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -24,13 +24,14 @@ use serde_yaml::Value;
 
 use fdo_data_formats::{
     constants::{HashType, PublicKeyType, RendezvousVariable, TransportProtocol},
+    devicecredential::FileDeviceCredential,
     enhanced_types::RendezvousInterpreterSide,
     messages,
     ownershipvoucher::{OwnershipVoucher, OwnershipVoucherHeader},
     publickey::{PublicKey, PublicKeyBody, X5Chain},
     types::{
-        COSESign, DeviceCredential, Guid, HMac, Hash, RendezvousDirective, RendezvousInfo, TO0Data,
-        TO1DataPayload, TO2AddressEntry,
+        COSESign, Guid, HMac, Hash, RendezvousDirective, RendezvousInfo, TO0Data, TO1DataPayload,
+        TO2AddressEntry,
     },
     PROTOCOL_VERSION,
 };
@@ -428,7 +429,7 @@ fn initialize_device(matches: &ArgMatches) -> Result<(), Error> {
 
     // Build device credential
     let device_guid = Guid::new().context("Error generating guid")?;
-    let devcred = DeviceCredential {
+    let devcred = FileDeviceCredential {
         active: true,
         protver: PROTOCOL_VERSION,
         hmac_secret: hmac_key_buf.to_vec(),
@@ -551,7 +552,7 @@ fn dump_voucher(matches: &ArgMatches) -> Result<(), Error> {
 fn dump_devcred(matches: &ArgMatches) -> Result<(), Error> {
     let devcred_path = matches.value_of("path").unwrap();
 
-    let dc: DeviceCredential = {
+    let dc: FileDeviceCredential = {
         let dc_file = fs::File::open(&devcred_path)
             .with_context(|| format!("Error opening device credential at {}", devcred_path))?;
         serde_cbor::from_reader(dc_file).context("Error loading device credential")?


### PR DESCRIPTION
Abstract the DeviceCredential to allow cases where the DeviceCredential
gets synthesized from TPM NV Indexes or other sources.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>