### PR TITLE
chore: set up CD for release branches

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - main
+    - "*.*.x"
     tags:
     - v*
   schedule:


### PR DESCRIPTION
This should make CD run on release branches, like 0.4.x.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>