### PR TITLE
[DO NOT MERGE] chore: add integration test for plain-di

### DIFF
--- a/integration-tests/templates/manufacturing-server.yml.j2
+++ b/integration-tests/templates/manufacturing-server.yml.j2
@@ -20,6 +20,7 @@ rendezvous_info:
   owner_port: {{ rendezvous_port }}
   protocol: http
 protocols:
+  plain_di: {{ plain_di }}
   diun:
     key_path: {{ keys_path }}/diun_key.der
     cert_path: {{ keys_path }}/diun_cert.pem

--- a/integration-tests/tests/e2e.rs
+++ b/integration-tests/tests/e2e.rs
@@ -168,6 +168,7 @@ where
                     cfg.insert("diun_key_type", diun_key_type);
                     cfg.insert("rendezvous_port", &rendezvous_server.server_port().unwrap());
                     cfg.insert("device_identification_format", "SerialNumber");
+                    cfg.insert("plain_di", "false"); // TODO
                     Ok(())
                 })?)
             },


### PR DESCRIPTION
This PR demonstrates the issue of https://github.com/fedora-iot/fido-device-onboard-rs/issues/477
The test passes because the it does not load the public key but it fails if the public key is loaded by `store.load_data()` as current code does.