### PR TITLE
fix(admin-tool): call the 'fdo-owner-tool' with the correct arguments

### DIFF
--- a/admin-tool/src/aio/device.rs
+++ b/admin-tool/src/aio/device.rs
@@ -125,7 +125,7 @@ async fn print_device_credential(
     let status =
         tokio::process::Command::new(binary_path.join(ChildBinary::OwnerTool.binary_name()))
             .arg("dump-device-credential")
-            .args(device_credential_path)
+            .arg(device_credential_path)
             .status()
             .await
             .context("Error running owner-tool to dump device credential")?;


### PR DESCRIPTION
Fix the `fdo-admin-tool aio device manufacture` command which fails
when running the `fdo-owner-tool dump-device-credential` command
after the manufacturing process has finished successfully.

Closes #563

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
