### PR TITLE
fix: integration-tests: remove users crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,7 +1511,6 @@ dependencies = [
  "tempfile",
  "tera",
  "tokio",
- "users",
 ]
 
 [[package]]
@@ -3149,16 +3148,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,7 +33,6 @@ serde_json = "1.0"
 pretty_assertions = "1.0.0"
 paste = "1.0"
 pem = "2.0"
-users = "0.11.0"
 
 fdo-data-formats = { path = "../data-formats" }
 fdo-util = { path = "../util" }

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -808,21 +808,19 @@ impl<'a> TestServerConfigurator<'a> {
                     &self.test_context.runner_path(&self.server_number),
                 );
 
+                let output = Command::new("whoami").output().unwrap();
+
+                let cur_user = String::from_utf8(output.stdout).unwrap();
+
                 if !per_device {
                     L.l("per_device_serviceinfo is not set, using default values");
-                    cfg.insert(
-                        "user",
-                        users::get_current_username().unwrap().to_str().unwrap(),
-                    );
+                    cfg.insert("user", &cur_user);
                     cfg.insert("sshkey1", "ssh-ed25519 sshkey_default user@example.com");
                     cfg.insert("sshkey2", "ssh-ed25519 sshkey_default user@example2.com");
                     cfg.insert("password", "testpassword");
                 } else {
                     L.l("per_device_serviceinfo is set, using device specific values");
-                    cfg.insert(
-                        "user",
-                        users::get_current_username().unwrap().to_str().unwrap(),
-                    );
+                    cfg.insert("user", &cur_user);
                     cfg.insert("sshkey1", "ssh-ed25519 sshkey_per_device user@example.com");
                     cfg.insert("sshkey2", "ssh-ed25519 sshkey_per_device user@example2.com");
                     cfg.insert("password", "testpassword");


### PR DESCRIPTION
The users crate has been unmaintained for some time. This fix replaces its functionality with terminal commands resulting in the same output, and removes the users crate from the dependencies.

Fixes #566