### PR TITLE
chore: fix Fedora Packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,32 +17,29 @@ srpm_build_deps:
 
 actions:
   create-archive:
-  - "cargo vendor vendor"
+  - bash -c "sed -i -r \"s/Source0:.+/Source0:\ fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar/\" fido-device-onboard.spec"
+  - bash -c "sed -i \"/Source1/d\" fido-device-onboard.spec"
   - bash -c "git archive --prefix=fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}/ --format=tar HEAD > fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar"
   - bash -c "tar -xvf fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar"
-  - bash -c "cp -Ra vendor fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}"
-  - bash -c "tar -czf fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar.gz fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}"
-  - bash -c "rm -rf fido-device-onboard-rs-${PACKIT_PROJECT_VERSION} fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar vendor"
-  - bash -c "ls -1 ./fido-device-onboard-rs-*.tar.gz"
+  - bash -c "ls -1 ./fido-device-onboard-rs-${PACKIT_PROJECT_VERSION}.tar"
   fix-spec-file:
-  - sed -i fido-device-onboard.spec -e "s/with_packit 0/with_packit 1/"
-  - bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" fido-device-onboard.spec"
+  - "cat fido-device-onboard.spec"
 
 jobs:
 - job: copr_build
   trigger: pull_request
   targets:
-  - centos-stream-9-aarch64
-  - centos-stream-9-x86_64
   - fedora-development-aarch64
   - fedora-development
+  - fedora-latest
+  - fedora-latest-aarch64
 - job: copr_build
   trigger: commit
   branch: main
   owner: "@fedora-iot" # copr repo namespace
   project: fedora-iot  # copr repo name so you can consume the builds
   targets:
-  - centos-stream-9-aarch64
-  - centos-stream-9-x86_64
   - fedora-development-aarch64
   - fedora-development
+  - fedora-latest
+  - fedora-latest-aarch64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,9 +1844,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if 1.0.0",
@@ -1890,9 +1890,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Fixes #506 

Builds are working for Fedora 40, Fedora 39 needs a package that is moving from testing to stable at the end of the day.