### PR TITLE
chore: fix clippy warnings after rustc v1.75.0 update

### DIFF
--- a/client-linuxapp/src/reencrypt/rebind.rs
+++ b/client-linuxapp/src/reencrypt/rebind.rs
@@ -48,7 +48,7 @@ fn get_clevis_keyslot(dev: &mut CryptDevice, clevis_token: u32) -> Result<u32> {
         .ok_or_else(|| anyhow!("No keyslots found in clevis token"))?
         .as_array()
         .ok_or_else(|| anyhow!("Invalid JSON type returned from clevis token keyslots"))?
-        .get(0)
+        .first()
         .ok_or_else(|| anyhow!("No keyslots found in clevis token"))?
         .as_str()
         .ok_or_else(|| anyhow!("Invalid JSON type returned from clevis token keyslot"))?

--- a/data-formats/src/publickey.rs
+++ b/data-formats/src/publickey.rs
@@ -343,7 +343,7 @@ impl X5Chain {
     }
 
     pub fn leaf_certificate(&self) -> Option<&X509> {
-        self.chain.get(0)
+        self.chain.first()
     }
 
     pub fn from_slice(data: &[u8]) -> Result<Self> {

--- a/data-formats/src/types.rs
+++ b/data-formats/src/types.rs
@@ -259,7 +259,7 @@ impl Nonce {
     }
 
     pub fn from_value(val: &[u8]) -> Result<Self, Error> {
-        Ok(Nonce(val.try_into().map_err(|_| Error::IncorrectNonce)?))
+        Ok(Nonce(val.into()))
     }
 
     pub fn value(&self) -> &[u8] {
@@ -326,7 +326,7 @@ impl Guid {
         if data[0] != EAT_RAND {
             Err(Error::InconsistentValue("Invalid UEID"))
         } else {
-            Ok(Guid(data[1..].try_into().unwrap()))
+            Ok(Guid(data[1..].into()))
         }
     }
 }


### PR DESCRIPTION
fix clippy warnings after rustc v1.75.0 update