### PR TITLE
chore: bump warp requirement explicitly to 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "deunicode"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2912,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -3013,13 +3019,13 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
@@ -3194,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -24,7 +24,7 @@ aws-nitro-enclaves-cose = "0.4.0"
 
 # Server-side
 uuid = { version = "1.3", features = ["v4"], optional = true }
-warp = { version = "0.3", optional = true }
+warp = { version = "0.3.6", optional = true }
 warp-sessions = { version = "1.0", optional = true }
 time = "0.3"
 

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"
 openssl = "0.10.60"
-warp = "0.3"
+warp = "0.3.6"
 log = "0.4"
 hex = "0.4"
 serde_yaml = "0.9"

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"
 openssl = "0.10.60"
-warp = "0.3"
+warp = "0.3.6"
 serde_bytes = "0.11"
 serde_cbor = "0.11"
 log = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 thiserror= "1"
 serde = "1"
 openssl = "0.10.60"
-warp = "0.3"
+warp = "0.3.6"
 log = "0.4"
 time = "0.3"
 

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1"
 config = "0.13.3"
 hex = "0.4"
 tokio = { version = "1", features = ["full"] }
-warp = "0.3"
+warp = "0.3.6"
 log = "0.4"
 serde = "1"
 serde_bytes = "0.11"


### PR DESCRIPTION
There's a pair of security issues in warp dependencies prior to 0.3.6 so bump this to at least that so we get the fixes forr
 tungstenite and rustls dependencies.