### PR TITLE
Fix hashing of Device Certificate Chain in Ownership Voucher

### DIFF
--- a/manufacturing-server/src/handlers/di.rs
+++ b/manufacturing-server/src/handlers/di.rs
@@ -110,7 +110,14 @@ pub(crate) async fn app_start(
     let device_certificate_chain =
         create_device_cert_chain(&user_data.device_cert_chain, device_certificate);
     let device_certificate_chain_serialized = device_certificate_chain
-        .serialize_data()
+        .chain()
+        .iter()
+        .try_fold(vec![], |mut bytes, cert| {
+            cert.to_der().map(|der| {
+                bytes.extend(der);
+                bytes
+            })
+        })
         .map_err(Error::from_error::<messages::v11::di::AppStart, _>)?;
     let device_certificate_chain_hash =
         Hash::from_data(HashType::Sha384, &device_certificate_chain_serialized)


### PR DESCRIPTION
The specification states that “OVDevCertChainHash is the Hash of the concatenation of the contents of each byte string in OwnershipVoucher.OVDevCertChain, in the presented order."

The current behavior is to serialize the X5CHAIN to CBOR (i.e. `[ bstr[cert1] ... bstr[certN] ]` instead of `cert1 || ... || certN`).

See https://fidoalliance.org/specs/FDO/FIDO-Device-Onboard-PS-v1.1-20220419/FIDO-Device-Onboard-PS-v1.1-20220419.html#OwnershipVoucher

BREAKING CHANGE: The device certificate chain hash in ownership voucher is now calculated from the concatenation of certificate ASN.1 DER contents rather than the CBOR serialization of an array of byte strings.