### PR TITLE
chore: bump for 0.4.13 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-admin-tool"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-client-linuxapp"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "devicemapper",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "assert-str",
  "cbindgen",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data-formats"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "byteorder",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-http-wrapper"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-client"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "config",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-onboarding-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "config",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-tool"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "clap 4.3.0",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-rendezvous-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "config",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "config",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-store"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "async-trait",
  "fdo-data-formats",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-util"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "config",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "anyhow",
  "fdo-data-formats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ default-members = [
     "serviceinfo-api-server",
     "admin-tool",
 ]
+
+resolver = "2"

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-admin-tool"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -21,10 +21,10 @@ pretty_env_logger = "0.5"
 nix = "0.26"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.12", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.13", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.13" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,6 +21,6 @@ secrecy = "0.8"
 devicemapper = "0.34"
 openssl = "0.10.60"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -3,7 +3,7 @@
 %global combined_license Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache 2.0) AND ISC AND MIT AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (Apache-2.0 OR MIT OR Zlib) AND MPL-2.0 AND (Unlicense OR MIT)
 
 Name:           fido-device-onboard
-Version:        0.4.12
+Version:        0.4.13
 Release:        1%{?dist}
 Summary:        A rust implementation of the FIDO Device Onboard Specification
 License:        BSD-3-Clause
@@ -265,6 +265,9 @@ Requires: fdo-init = %{version}-%{release}
 %systemd_postun_with_restart fdo-aio.service
 
 %changelog
+* Thu Jan 25 2024 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.13-1
+- Update to 0.4.13
+
 * Wed Jul 26 2023 Peter Robinson <pbrobinson@fedoraproject.org> - 0.4.12-1
 - Update to 0.4.12
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10.60"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-store = { path = "../store", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-store = { path = "../store", version = "0.4.13" }
 aws-nitro-enclaves-cose = { git = "https://github.com/nullr0ute/aws-nitro-enclaves-cose/", rev = "e3938e60d9051690569d1e4fcbe1c0c99d2fafa8" }
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -12,7 +12,7 @@
 
 #define FDO_DATA_MAJOR 0
 #define FDO_DATA_MINOR 4
-#define FDO_DATA_PATCH 12
+#define FDO_DATA_PATCH 13
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,6 +17,6 @@ rand = "0.8.4"
 tss-esapi = { version = "7.4", features = ["generate-bindings"] }
 regex = "1.3.7"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["client"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["client"] }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ log = "0.4"
 hex = "0.4"
 serde_yaml = "0.9"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.12", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.13", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.4.12", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.4.13", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -16,9 +16,8 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 tss-esapi = { version = "7.4", features = ["generate-bindings"] }
 
-fdo-util = { path = "../util", version = "0.4.12" }
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["client"] }
-
+fdo-util = { path = "../util", version = "0.4.13" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["client"] }
 
 hex = "0.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3.6"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server"] }
-fdo-store = { path = "../store", version = "0.4.12" }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server"] }
+fdo-store = { path = "../store", version = "0.4.13" }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-serviceinfo-api-server"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,7 +16,7 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server"] }
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-store = { path = "../store", version = "0.4.12", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.4.12" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-store = { path = "../store", version = "0.4.13", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.4.13" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fdo-store"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
 
 thiserror = "1"
 async-trait = "0.1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ glob = "0.3.1"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.4.12" }
-fdo-store = { path = "../store", version = "0.4.12" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.12", features = ["server", "client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
+fdo-store = { path = "../store", version = "0.4.13" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.4.13", features = ["server", "client"] }
 serde_yaml = "0.9"
 serde_cbor = "0.11"
 serde_json = "1"


### PR DESCRIPTION
Prepare for the 0.4.13 release. This has a fix
for how we deal with OVs as well as bumping
numerous crates with security issues.