### PR TITLE
chore: update patch for new release

### DIFF
--- a/0001-Revert-chore-use-git-fork-for-aws-nitro-enclaves-cos.patch
+++ b/0001-Revert-chore-use-git-fork-for-aws-nitro-enclaves-cos.patch
@@ -28,8 +28,8 @@ index 5d4999c..7b98097 100644
 +++ b/http-wrapper/Cargo.toml
 @@ -20,7 +20,7 @@ openssl = "0.10.60"
  
- fdo-data-formats = { path = "../data-formats", version = "0.4.13" }
- fdo-store = { path = "../store", version = "0.4.13" }
+ fdo-data-formats = { path = "../data-formats", version = "0.5.0" }
+ fdo-store = { path = "../store", version = "0.5.0" }
 -aws-nitro-enclaves-cose = { git = "https://github.com/nullr0ute/aws-nitro-enclaves-cose/", rev = "e3938e60d9051690569d1e4fcbe1c0c99d2fafa8" }
 +aws-nitro-enclaves-cose = "0.4.0"
  


### PR DESCRIPTION
Update the fedora patch to fix the aws-cose crate issue with the new version.