### PR TITLE
chore: fix require error with commitlint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,14 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const { maxLineLength } = require('@commitlint/ensure')
+const validateBodyMaxLengthIgnoringDeps = async (parsedCommit) => {
+  const { maxLineLength } = await import('@commitlint/ensure');
 
-const bodyMaxLineLength = 100
-
-const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
   const { type, scope, body } = parsedCommit
   const isDepsCommit =
       type === 'chore'
       && body != null
       && body.includes('Updates the requirements on');
+
+  const bodyMaxLineLength = 100;
 
   return [
     isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),


### PR DESCRIPTION
Changed the commitlint config file to use a dynamic import of `commitlint/esnure` and updated the function to await the promise of the import.

(This code was generated by ChatGPT and appears to fix the error with using `require('@commitlint/ensure')`)

Closes: #633