### PR TITLE
fix(get_current_user_name): remove trailing whitespaces.

### DIFF
--- a/util/src/system_info.rs
+++ b/util/src/system_info.rs
@@ -10,4 +10,6 @@ pub fn get_current_user_name() -> String {
             .stdout,
     )
     .expect("Unable to read current user name")
+    .trim()
+    .to_string()
 }


### PR DESCRIPTION
Remove traling whitespaces from `id -un` output.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>