### PR TITLE
Add an OV re-registration window option when using DB storage

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -453,6 +453,8 @@ owner_addresses:
     - dns_name: fdo.example.com
     - ip_address: 192.168.122.1
 report_to_rendezvous_endpoint_enabled: false
+ov_registration_period: 600
+ov_re_registration_window: 61
 bind: 0.0.0.0:8081
 service_info_api_url: "http://localhost:8089/device_info"
 service_info_api_authentication: None
@@ -512,6 +514,12 @@ Where:
   - `port`: connection port.
 - `report_to_rendezvous_endpoint_enabled`: whether reporting to the Rendezvous
   Server is enabled or not, boolean.
+- `ov_registration_period`: optional value that sets how many seconds OVs are
+  going to be registered into the Rendezvous server.
+- `ov_re_registration_window`: optional value that sets the minimum amount of
+  seconds left in the `ov_registration_period` for the Owner server to trigger
+  a re-registration within the Rendezvous server. This option can only be used
+  with database backends.
 
 ### `rendezvous-server.yml`
 

--- a/admin-tool/src/aio/configure.rs
+++ b/admin-tool/src/aio/configure.rs
@@ -7,6 +7,8 @@ use std::{collections::BTreeMap, net::IpAddr, path::Path};
 
 use fdo_store::StoreConfig;
 use fdo_util::servers::configuration::{
+    owner_onboarding_server::DEFAULT_REGISTRATION_PERIOD,
+    owner_onboarding_server::DEFAULT_RE_REGISTRATION_WINDOW,
     serviceinfo_api_server::ServiceInfoSettings, AbsolutePathBuf, Bind,
 };
 
@@ -46,6 +48,11 @@ pub(super) struct Configuration {
     #[clap(long)]
     pub manufacturing_use_secp256r1: bool,
 
+    #[clap(long)]
+    ov_registration_period: Option<u32>,
+    #[clap(long)]
+    ov_re_registration_window: Option<u32>,
+
     /// The hostname or IP address that clients should use to connect to the AIO components
     /// (if not specified, will be all IP addresses of the system).
     /// Note that this is not equal to the listen address, as the AIO components will always
@@ -57,6 +64,7 @@ pub(super) struct Configuration {
     // and generate the intermediate data
     #[clap(skip)]
     pub contact_addresses: Vec<ContactAddress>,
+
     #[clap(skip)]
     pub serviceinfo_api_auth_token: String,
     #[clap(skip)]
@@ -87,6 +95,9 @@ impl Default for Configuration {
             manufacturing_disable_key_storage_filesystem: false,
             manufacturing_disable_key_storage_tpm: true,
             manufacturing_use_secp256r1: false,
+
+            ov_registration_period: Some(DEFAULT_REGISTRATION_PERIOD),
+            ov_re_registration_window: Some(DEFAULT_RE_REGISTRATION_WINDOW),
 
             contact_hostname: None,
 
@@ -339,6 +350,9 @@ fn generate_configs(aio_dir: &Path, config_args: &Configuration) -> Result<(), E
                 .generate_owner_addresses()
                 .context("Error generating owner addresses")?,
             report_to_rendezvous_endpoint_enabled: true,
+
+            ov_registration_period: config_args.ov_registration_period,
+            ov_re_registration_window: config_args.ov_re_registration_window,
         };
     write_config(
         aio_dir,

--- a/store/src/db.rs
+++ b/store/src/db.rs
@@ -154,6 +154,14 @@ where
         Err(StoreError::MethodNotAvailable)
     }
 
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        _to2: bool,
+        _to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        Err(StoreError::MethodNotAvailable)
+    }
+
     async fn store_data(&self, _key: K, value: V) -> Result<(), StoreError> {
         let pool = fdo_db::sqlite::SqliteManufacturerDB::get_conn_pool();
         let conn = &mut pool.get().expect("Couldn't establish a connection");
@@ -338,6 +346,34 @@ where
         Ok(ret)
     }
 
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        to2: bool,
+        to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        let mut ret = vec![];
+        let pool = fdo_db::sqlite::SqliteOwnerDB::get_conn_pool();
+        let conn = &mut pool
+            .get()
+            .map_err(|e| StoreError::Database(format!("Error connecting to DB {e:?}")))?;
+        let db_ovs = fdo_db::sqlite::SqliteOwnerDB::select_ov_to2_performed_and_ov_to0_less_than(
+            false, to0_max, conn,
+        )
+        .map_err(|e| {
+            StoreError::Database(format!(
+                "Error selecting OVs filering by to2 {to2} and to0 {to0_max}: {e:?}"
+            ))
+        })?;
+        for db_ov in db_ovs {
+            ret.push(
+                OwnershipVoucher::from_pem_or_raw(&db_ov.contents).map_err(|e| {
+                    StoreError::Unspecified(format!("Error parsing OV contents from DB: {e:?}"))
+                })?,
+            );
+        }
+        Ok(ret)
+    }
+
     async fn store_data(&self, _key: K, value: V) -> Result<(), StoreError> {
         let pool = fdo_db::sqlite::SqliteOwnerDB::get_conn_pool();
         let conn = &mut pool.get().expect("Couldn't establish a connection");
@@ -468,6 +504,14 @@ where
     }
 
     async fn query_ovs_db(&self) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        Err(StoreError::MethodNotAvailable)
+    }
+
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        _to2: bool,
+        _to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
         Err(StoreError::MethodNotAvailable)
     }
 
@@ -603,6 +647,14 @@ where
     }
 
     async fn query_ovs_db(&self) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        Err(StoreError::MethodNotAvailable)
+    }
+
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        _to2: bool,
+        _to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
         Err(StoreError::MethodNotAvailable)
     }
 
@@ -793,6 +845,35 @@ where
         Ok(ret)
     }
 
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        to2: bool,
+        to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        let mut ret = vec![];
+        let pool = fdo_db::postgres::PostgresOwnerDB::get_conn_pool();
+        let conn = &mut pool
+            .get()
+            .map_err(|e| StoreError::Database(format!("Error connecting to DB {e:?}")))?;
+        let db_ovs =
+            fdo_db::postgres::PostgresOwnerDB::select_ov_to2_performed_and_ov_to0_less_than(
+                false, to0_max, conn,
+            )
+            .map_err(|e| {
+                StoreError::Database(format!(
+                    "Error selecting OVs filering by to2 {to2} and to0 {to0_max}: {e:?}"
+                ))
+            })?;
+        for db_ov in db_ovs {
+            ret.push(
+                OwnershipVoucher::from_pem_or_raw(&db_ov.contents).map_err(|e| {
+                    StoreError::Unspecified(format!("Error parsing OV contents from DB: {e:?}"))
+                })?,
+            );
+        }
+        Ok(ret)
+    }
+
     async fn store_data(&self, _key: K, value: V) -> Result<(), StoreError> {
         let pool = fdo_db::postgres::PostgresOwnerDB::get_conn_pool();
         let conn = &mut pool.get().expect("Couldn't establish a connection");
@@ -923,6 +1004,14 @@ where
     }
 
     async fn query_ovs_db(&self) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        Err(StoreError::MethodNotAvailable)
+    }
+
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        _to2: bool,
+        _to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
         Err(StoreError::MethodNotAvailable)
     }
 

--- a/store/src/directory.rs
+++ b/store/src/directory.rs
@@ -302,6 +302,14 @@ where
         Err(StoreError::MethodNotAvailable)
     }
 
+    async fn query_ovs_db_to2_performed_to0_less_than(
+        &self,
+        _to2: bool,
+        _to0_max: i64,
+    ) -> Result<Vec<OwnershipVoucher>, StoreError> {
+        Err(StoreError::MethodNotAvailable)
+    }
+
     async fn store_data(&self, key: K, value: V) -> Result<(), StoreError> {
         let finalpath = self.get_path(&key);
         let mut path = finalpath.clone();

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -197,6 +197,17 @@ pub trait Store<OT: StoreOpenMode, K, V, MKT: MetadataLocalKey>: Send + Sync {
         'life0: 'async_trait,
         Self: 'async_trait;
 
+    fn query_ovs_db_to2_performed_to0_less_than<'life0, 'async_trait>(
+        &'life0 self,
+        to2: bool,
+        to0_max: i64,
+    ) -> Pin<
+        Box<dyn Future<Output = Result<Vec<OwnershipVoucher>, StoreError>> + 'async_trait + Send>,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait;
+
     fn store_data<'life0, 'async_trait>(
         &'life0 self,
         key: K,

--- a/util/src/servers/configuration/owner_onboarding_server.rs
+++ b/util/src/servers/configuration/owner_onboarding_server.rs
@@ -32,4 +32,12 @@ pub struct OwnerOnboardingServerSettings {
     pub owner_addresses: Vec<RemoteConnection>,
 
     pub report_to_rendezvous_endpoint_enabled: bool,
+
+    pub ov_registration_period: Option<u32>,
+    pub ov_re_registration_window: Option<u32>,
 }
+
+// 10 minutes
+pub const DEFAULT_REGISTRATION_PERIOD: u32 = 600;
+// ~1 minute
+pub const DEFAULT_RE_REGISTRATION_WINDOW: u32 = 61;


### PR DESCRIPTION
This allows the users to specify an OV re-registration window in the Owner server. When an OV is about to be de-registered in the rendezvous server within the specified time window, the owner will trigger a re-registration.

Fixes #193 
Obsoletes #207 