### PR TITLE
fix(systemd-units): run before powering off the system

### DIFF
--- a/dracut/52fdo/manufacturing-client.service
+++ b/dracut/52fdo/manufacturing-client.service
@@ -3,6 +3,8 @@ Description=Manufacturing client DIUN
 DefaultDependencies=false
 
 After=coreos-installer.service
+Before=coreos-installer-poweroff.service
+Before=coreos-installer-noreboot.service
 Before=coreos-installer-reboot.service
 ConditionPathExists=/etc/manufacturing-client-config
 Requires=dev-disk-by\x2dlabel-boot.device


### PR DESCRIPTION
Run before coreos-installer-poweroff.service and
coreos-installer-noreboot.service systemd units.

Otherwise the coreos-installer-poweroff.service and
the manufacturing-client.service are run in parallel
and the manufacturing client can be stopped before
finishing the manufacturing process.

Resolves: RHEL-38482

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
