### PR TITLE
fix(dracut): use isolate on error in the manufacturing-client service

### DIFF
--- a/dracut/52fdo/manufacturing-client.service
+++ b/dracut/52fdo/manufacturing-client.service
@@ -10,7 +10,7 @@ ConditionPathExists=/etc/manufacturing-client-config
 Requires=dev-disk-by\x2dlabel-boot.device
 
 OnFailure=emergency.target
-OnFailureJobMode=replace-irreversibly
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Use 'isolate' instead of 'replace-irreversibly' for the manufacturing-client
service to prevent the `coreos-installer` service to be respawned when
the manufacturing-client fails.

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
