### PR TITLE
enhance onboarding testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,9 +34,9 @@ jobs:
           fedora-latest-stable: {}
           fedora-latest: {}
           fedora-rawhide: {}
-          fedora-eln:
-              additional_repos:
-                  - https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
+#          fedora-eln:
+#              additional_repos:
+#                  - https://kojipkgs.fedoraproject.org/repos/eln-build/latest/$basearch/
 
     - job: tests
       trigger: pull_request
@@ -48,6 +48,7 @@ jobs:
           fedora-latest-stable: {}
           fedora-latest: {}
           fedora-rawhide: {}
+#          fedora-eln: {}
 
     - <<: *fdo_copr_build
       trigger: commit

--- a/test/fmf/plans/onboarding.fmf
+++ b/test/fmf/plans/onboarding.fmf
@@ -6,6 +6,20 @@ execute:
 prepare:
     - how: shell
       script: dnf install -y postgresql-server sqlite
+    - how: shell
+      script: |
+        echo "Adding missing SELinux permissions"
+        tee /tmp/fdo-missing.cil <<EOF
+        (allow fdo_t etc_t (file (write)))
+        (allow fdo_t fdo_conf_t (file (append create rename setattr unlink write)))
+        (allow fdo_t fdo_var_lib_t (dir (add_name remove_name write)))
+        (allow fdo_t fdo_var_lib_t (file (create setattr unlink write)))
+        (allow fdo_t krb5_keytab_t (dir (search)))
+        (allow fdo_t postgresql_port_t (tcp_socket (name_connect)))
+        (allow fdo_t sssd_t (unix_stream_socket (connectto)))
+        (allow fdo_t sssd_var_run_t (sock_file (write)))
+        EOF
+        semodule -i /tmp/fdo-missing.cil
 provision:
     how: virtual
     memory: 4096

--- a/test/fmf/tests/onboarding/run-onboarding.sh
+++ b/test/fmf/tests/onboarding/run-onboarding.sh
@@ -197,21 +197,11 @@ setup_rendezvous
 setup_serviceinfo
 systemctl restart fdo-{manufacturing,owner-onboarding,rendezvous,serviceinfo-api}-server.service
 # Wait for servers to be up and running
-until [ "$(curl -X POST http://${PRIMARY_IP}:8080/ping)" == "pong" ]; do
-    sleep 1;
-done;
-
-until [ "$(curl -X POST http://${PRIMARY_IP}:8081/ping)" == "pong" ]; do
-    sleep 1;
-done;
-
-until [ "$(curl -X POST http://${PRIMARY_IP}:8082/ping)" == "pong" ]; do
-    sleep 1;
-done;
-
-until [ "$(curl -X POST http://${PRIMARY_IP}:8083/ping)" == "pong" ]; do
-    sleep 1;
-done;
+for PORT in 808{0..3}; do
+  until [ "$(curl -s -X POST http://${PRIMARY_IP}:${PORT}/ping)" == "pong" ]; do
+      sleep 1;
+  done;
+done
 perform_no_plain_di
 [ "${OV_STORE_DRIVER}" = "Directory" ] || export_import_vouchers
 sleep 60

--- a/test/fmf/tests/onboarding/run-onboarding.sh
+++ b/test/fmf/tests/onboarding/run-onboarding.sh
@@ -60,7 +60,7 @@ setup_postgresql() {
 setup_sqlite() {
   mkdir -p ${DATABASE_DIR}
   DATABASE_FILE="${DATABASE_DIR}/fido-device-onboard.db"
-  > ${DATABASE_FILE}
+  true > ${DATABASE_FILE}
   for DATABASE in ${DATABASES}; do
     sqlite3 ${DATABASE_FILE} < "${MIGRATIONS_BASE_DIR}/migrations_${DATABASE}_server_sqlite/up.sql"
   done
@@ -164,7 +164,6 @@ admin_auth_token: Va40bSkLcxwnfml1pmIuaWaOZG96mSMB6fu0xuzcueg=
 device_specific_store_driver:
   Directory:
     path: ${STORES_DIR}/serviceinfo_api_devices
-
 EOF
 }
 
@@ -175,7 +174,7 @@ export_import_vouchers() {
   fdo-owner-tool export-manufacturer-vouchers "http://${PRIMARY_IP}:8080" --path "${MANUFACTURER_EXPORT_DIR}"
   sudo tar xvf "${MANUFACTURER_EXPORT_DIR}"/export.tar -C "${MANUFACTURER_EXPORT_DIR}"
   sudo rm -rf "${MANUFACTURER_EXPORT_DIR}"/export.tar
-  fdo-owner-tool import-ownership-vouchers "$(tr [:upper:] [:lower:] <<< ${OV_STORE_DRIVER})" "${DATABASE_URL}" "${MANUFACTURER_EXPORT_DIR}"
+  fdo-owner-tool import-ownership-vouchers "$(tr "[:upper:]" "[:lower:]" <<< "${OV_STORE_DRIVER}")" "${DATABASE_URL}" "${MANUFACTURER_EXPORT_DIR}"
 }
 
 perform_no_plain_di() {

--- a/test/fmf/tests/onboarding/run-onboarding.sh
+++ b/test/fmf/tests/onboarding/run-onboarding.sh
@@ -179,13 +179,13 @@ export_import_vouchers() {
 
 perform_no_plain_di() {
   rm -f "${DEVICE_CREDENTIAL}" "${ONBOARDING_PERFORMED}"
-  /usr/libexec/fdo/fdo-manufacturing-client no-plain-di \
-                                            --manufacturing-server-url http://${PRIMARY_IP}:8080 \
-                                            --rootcerts ${KEYS_DIR}/diun_cert.pem
+  LOG_LEVEL=trace /usr/libexec/fdo/fdo-manufacturing-client no-plain-di \
+                                                            --manufacturing-server-url http://${PRIMARY_IP}:8080 \
+                                                            --rootcerts ${KEYS_DIR}/diun_cert.pem
 }
 
 onboard() {
-  /usr/libexec/fdo/fdo-client-linuxapp
+  LOG_LEVEL=trace /usr/libexec/fdo/fdo-client-linuxapp
 }
 
 [ "${OV_STORE_DRIVER}" != "Sqlite" ] || setup_sqlite

--- a/test/fmf/tests/onboarding/run-onboarding.sh
+++ b/test/fmf/tests/onboarding/run-onboarding.sh
@@ -28,7 +28,7 @@ DATABASE_PASSWORD="redhat"
 [ "$DATABASE_DRIVER" != "postgresql" ] || DATABASE_URL="${DATABASE_DRIVER}://${DATABASE_USER}:${DATABASE_PASSWORD}@127.0.0.1/fdo"
 [ "$DATABASE_DRIVER" != "sqlite" ] || DATABASE_URL="${DATABASE_DRIVER}://${DATABASE_DIR}/fido-device-onboard.db"
 
-generate_keys() {
+generate_fdo_certificates() {
   ORGANIZATION="Red Hat"
   COUNTRY="US"
   VALIDITY="3650"
@@ -190,7 +190,7 @@ onboard() {
 
 [ "${OV_STORE_DRIVER}" != "Sqlite" ] || setup_sqlite
 [ "${OV_STORE_DRIVER}" != "Postgres" ] || setup_postgresql
-generate_keys
+generate_fdo_certificates
 setup_manufacturing
 setup_owner
 setup_rendezvous


### PR DESCRIPTION
- **chore: Move SELinux fixes to plan preparation steps**
- **fix(shellcheck): fix shellcheck lint issues**
- **chore: use a more meaningful name for generate_keys function**
- **test: simplify the code checking FDO services**
- **test: increase verbosity for FDO clients**
- **tests: add service infos to onboarding tests**
