### PR TITLE
fix: use centos-stream-9 target instead of epel-9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,7 @@ jobs:
       job: copr_build
       trigger: pull_request
       targets:
-          epel-9: {}
+          centos-stream-9: {}
           fedora-latest-stable: {}
           fedora-latest: {}
           fedora-rawhide: {}
@@ -44,7 +44,7 @@ jobs:
       fmf_path: test/fmf
       tmt_plan: plans/onboarding
       targets:
-          epel-9: {}
+          centos-stream-9: {}
           fedora-latest-stable: {}
           fedora-latest: {}
           fedora-rawhide: {}

--- a/test/fdo-postgres.sh
+++ b/test/fdo-postgres.sh
@@ -50,7 +50,7 @@ sudo rm -rf aio
 
 # Set servers store driver to postgres
 greenprint "🔧 Set servers store driver to postgres"
-sudo pip3 install yq
+sudo pipx install yq
 # Configure manufacturing server db
 yq -yi 'del(.ownership_voucher_store_driver.Directory)' test/fdo/manufacturing-server.yml
 yq -yi ".ownership_voucher_store_driver += {Postgres: {server: \"Manufacturer\", url: \"${DB_URL}\"}}" test/fdo/manufacturing-server.yml

--- a/test/fmf/plans/onboarding.fmf
+++ b/test/fmf/plans/onboarding.fmf
@@ -4,10 +4,8 @@ discover:
 execute:
     how: tmt
 prepare:
-    - how: install
-      copr: ${PACKIT_COPR_PROJECT}
     - how: shell
-      script: dnf install -y ${PACKIT_COPR_RPMS} postgresql-server sqlite
+      script: dnf install -y postgresql-server sqlite
 provision:
     how: virtual
     memory: 4096


### PR DESCRIPTION
Use the centos-stream-9 target as the epel-9 repos
don't seem to be up to date.

Remove the preparation steps enabling the copr repo
and installing the copr packages because it's not needed
and it's causing problems: Packit is supposed to enable the
copr repo and install all the packages contained in
that repo.

Use pipx instead of pip3 as suggested by the error
message to fix the postgres tests.