### PR TITLE
ci: add konflux test cases

### DIFF
--- a/konflux/README.md
+++ b/konflux/README.md
@@ -1,0 +1,53 @@
+# Konflux integration test cases
+As RedHat uses Konflux to build, verify and release containers now, all fdo containers will be built in konflux. The integration test cases defined in this folder will be triggered by konflux when new fdo container images are built.
+
+## How konflux trigger test cases
+konflux defines integration test workflow in this file: (when writing this doc, below files are not merged into konflux yet, will update it later)
+- https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2167/diffs#3904e36f53d22f073f197dedd0bd6355289a0053
+
+Within this file, it defines fdo repo url and test file path:
+- fdo repo: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2167/diffs#3904e36f53d22f073f197dedd0bd6355289a0053_0_15
+- test file: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2167/diffs#3904e36f53d22f073f197dedd0bd6355289a0053_0_19
+
+When konflux trigger integration test workflow, it will go to fdo repo and get the test file, and execute the tasks defined in test file.
+
+## Test files in this folder
+There are four pipeline files and one test file in this folder.
+- fdo-manufacturing-server-integration-tests.yaml
+- fdo-owner-onboarding-server-integration-tests.yaml
+- fdo-rendezvous-server-integration-tests.yaml
+- fdo-serviceinfo-api-server-integration-tests.yaml
+- fdo-container-test.yaml
+
+## Test case definition (manufacturing server test case as example)
+There are two yaml files for manufacturing server test.
+
+- fdo-manufacturing-server-integration-tests.yaml: This is the test file defined in konflux integration test workflow file, this file defines parameters, env variables and tasks. It also defines a task file path and pass all the parameters to that task file.
+  Example of parameters:
+  - SNAPSHOT: a parameter from konflux, it is basically the description of container that was built.
+  - GIT_URL: tell konflux which git repo to get
+  - GIT_REF: tell konflux which branch to use
+
+- fdo-container-test.yaml: This is the task file that defined in fdo-manufacturing-server-integration-tests.yaml, it defines some actions:
+  - get secrets from konflux
+  - set parameters
+  - get the url of fdo container we want to test
+  - run bash script
+
+## How to get fdo container
+In task yaml file, we can use parameter SNAPSHOT to retrieve container image url, the returned value will be like quay.io/fido-fdo/serviceinfo-api-server
+- IMAGE=$(echo "${SNAPSHOT}" | jq -r ".components[]|select(.name==\"$COMPONENT\")|.containerImage")
+
+## How to set test runner
+In task yaml file, we can specify the os and version of test runner to execute all the actions.
+Set image like this, "- image: quay.io/testing-farm/cli:latest"
+- It means to use the latest testing-farm cli container as runner, the benefit is that if you want to reserve a testing-farm machine to run test cases, you can use testing-farm command directly in script section and no need to install testing-farm related packages. 
+- If you want to run test cases in this runner directly, just write all test cases in script section.
+  
+Depends on the os of test runner, you need to use different commands in bash script.
+  - For testing-farm runner, run apk to install packages
+  - For RHEL, Centos-Stream, Fedora, run dnf or yum to install packages.
+
+
+
+

--- a/konflux/fdo-container-test.yaml
+++ b/konflux/fdo-container-test.yaml
@@ -1,0 +1,74 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: fdo-container-test
+spec:
+  description: Initiate test given a list of container images
+  params:
+    - name: SNAPSHOT
+      description: A list of container images that should undergo testing
+    - name: GIT_URL
+      description: URL of the GIT repository that contains the tests.
+    - name: GIT_REF
+      description: Branch of the git repository used containing the tests
+  volumes:
+    - name: podinfo
+      downwardAPI:
+        items:
+          - path: "labels"
+            fieldRef:
+              fieldPath: metadata.labels
+          - path: "annotations"
+            fieldRef:
+              fieldPath: metadata.annotations
+  steps:
+    - image: quay.io/testing-farm/cli:latest
+      volumeMounts:
+        - name: podinfo
+          mountPath: /etc/podinfo
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: GIT_URL
+          value: $(params.GIT_URL)
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+      script: |
+        #!/usr/bin/env bash
+        sed -i -e 's/v3\.15/v3\.16/g' /etc/apk/repositories
+        apk update
+        apk add --upgrade apk-tools
+        apk upgrade --available
+        apk add skopeo jq grep curl
+
+        cat /etc/podinfo/labels
+        PR_NAME=$(cat /etc/podinfo/labels | grep -oP '(?<=pipelineRun=")[^"]+')
+        COMPONENT=$(cat /etc/podinfo/labels | grep -oP '(?<=component=")[^"]+')
+        echo "PR_NAME:$PR_NAME"
+        echo "COMPONENT:$COMPONENT"
+
+        echo "${SNAPSHOT}"
+        IMAGE=$(echo "${SNAPSHOT}" | jq -r ".components[]|select(.name==\"$COMPONENT\")|.containerImage")
+        COUNT=$(echo "${SNAPSHOT}" | jq -r ".components|map(select(.name==\"$COMPONENT\"))|length")
+        if [[ ${COUNT} -ne 1 ]]; then
+          echo "Error: multiple images: ${IMAGES} in this application with component name: ${COMPONENT}"
+          exit 1
+        fi
+        echo $IMAGE
+
+        IMAGE_NAME=$(echo "${IMAGE##*/}" | cut -d @ -f 1)
+        IMAGE_TAG=$(echo "${IMAGE##*/}" | cut -d : -f 2)
+        echo "IMAGE_NAME:$IMAGE_NAME"
+        echo "IMAGE_TAG:$IMAGE_TAG"
+
+        skopeo inspect docker://"$IMAGE" > skopeo_inspect.json
+        cat skopeo_inspect.json
+        NAME=$(cat skopeo_inspect.json | jq -r ".Name")
+        echo "NAME:$NAME"
+        
+        if [[ "$NAME" =~ "$IMAGE_NAME" ]]; then
+          exit 0
+        else
+          exit 1
+        fi
+      timeout: "2h"

--- a/konflux/fdo-manufacturing-server-integration-tests.yaml
+++ b/konflux/fdo-manufacturing-server-integration-tests.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fdo manufacturing server integration tests
+spec:
+  description: >-
+    Expects a list of container images to be provided via the SNAPSHOT parameter.
+  params:
+    - name: SNAPSHOT
+      description: A list of fdo container images that should undergo testing
+      type: string
+    - name: GIT_URL
+      description: URL of the GIT repository that contains the tests.
+      default: "https://github.com/fdo-rs/fido-device-onboard-rs"
+      type: string
+    - name: GIT_REF
+      default: "main"
+      description: Branch of the git repository used containing the tests
+      type: string
+  tasks:
+    - name: fdo-container-test
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.GIT_URL)
+          - name: revision
+            value: $(params.GIT_REF)
+          - name: pathInRepo
+            value: konflux/fdo-container-test.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: GIT_URL
+          value: $(params.GIT_URL)
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+      timeout: "2h"

--- a/konflux/fdo-owner-onboarding-server-integration-tests.yaml
+++ b/konflux/fdo-owner-onboarding-server-integration-tests.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fdo owner onboarding server integration tests
+spec:
+  description: >-
+    Expects a list of container images to be provided via the SNAPSHOT parameter.
+  params:
+    - name: SNAPSHOT
+      description: A list of fdo container images that should undergo testing
+      type: string
+    - name: GIT_URL
+      description: URL of the GIT repository that contains the tests.
+      default: "https://github.com/fdo-rs/fido-device-onboard-rs"
+      type: string
+    - name: GIT_REF
+      default: "main"
+      description: Branch of the git repository used containing the tests
+      type: string
+  tasks:
+    - name: fdo-container-test
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.GIT_URL)
+          - name: revision
+            value: $(params.GIT_REF)
+          - name: pathInRepo
+            value: konflux/fdo-container-test.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: GIT_URL
+          value: $(params.GIT_URL)
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+      timeout: "2h"

--- a/konflux/fdo-rendezvous-server-integration-tests.yaml
+++ b/konflux/fdo-rendezvous-server-integration-tests.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fdo rendezvous server integration tests
+spec:
+  description: >-
+    Expects a list of container images to be provided via the SNAPSHOT parameter.
+  params:
+    - name: SNAPSHOT
+      description: A list of fdo container images that should undergo testing
+      type: string
+    - name: GIT_URL
+      description: URL of the GIT repository that contains the tests.
+      default: "https://github.com/fdo-rs/fido-device-onboard-rs"
+      type: string
+    - name: GIT_REF
+      default: "main"
+      description: Branch of the git repository used containing the tests
+      type: string
+  tasks:
+    - name: fdo-container-test
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.GIT_URL)
+          - name: revision
+            value: $(params.GIT_REF)
+          - name: pathInRepo
+            value: konflux/fdo-container-test.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: GIT_URL
+          value: $(params.GIT_URL)
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+      timeout: "2h"

--- a/konflux/fdo-serviceinfo-api-server-integration-tests.yaml
+++ b/konflux/fdo-serviceinfo-api-server-integration-tests.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: fdo serviceinfo api server integration tests
+spec:
+  description: >-
+    Expects a list of container images to be provided via the SNAPSHOT parameter.
+  params:
+    - name: SNAPSHOT
+      description: A list of fdo container images that should undergo testing
+      type: string
+    - name: GIT_URL
+      description: URL of the GIT repository that contains the tests.
+      default: "https://github.com/fdo-rs/fido-device-onboard-rs"
+      type: string
+    - name: GIT_REF
+      default: "main"
+      description: Branch of the git repository used containing the tests
+      type: string
+  tasks:
+    - name: fdo-container-test
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: $(params.GIT_URL)
+          - name: revision
+            value: $(params.GIT_REF)
+          - name: pathInRepo
+            value: konflux/fdo-container-test.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: GIT_URL
+          value: $(params.GIT_URL)
+        - name: GIT_REF
+          value: $(params.GIT_REF)
+      timeout: "2h"


### PR DESCRIPTION
To enable integration test in konflux, this pr added test cases that will be triggered by konflux mr https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/2167

This pr only includes simple check for those containers, after this pr and related konflux mr get merged, I can start to trigger the workflow and debug errors. After the whole konflux integration test workflow is verified, more test cases can be added later.

I have a concern:
konflux will build single fido container and trigger test, for example, it build manufacturing server container and then trigger test for manufacturing server. Konflux currently cannot build all fido containers at the same time and then trigger the test.
This brings two questions: 
1. If I remember correctly some fido container depends on other container to start, so if that fido container can not startup, we can only run some very simple checks.
2. We need all fido containers up and running to run a full fido onboarding test, test each fido container separately does not  make much sense.
