### PR TITLE
fix(make-vendored-tarfile.sh): exclude idna tests with unicode points

### DIFF
--- a/libfdo-data/src/lib.rs
+++ b/libfdo-data/src/lib.rs
@@ -41,6 +41,7 @@ pub unsafe extern "C" fn fdo_free_string(s: *mut c_char) {
 /// Note: The returned string ownership is transferred to the caller, and should
 /// be freed with `fdo_free_string`
 #[no_mangle]
+#[allow(unused_unsafe)]
 pub extern "C" fn fdo_get_last_error() -> *mut c_char {
     let result = unsafe { addr_of!(LAST_ERROR) };
     if result.is_null() {

--- a/make-vendored-tarfile.sh
+++ b/make-vendored-tarfile.sh
@@ -11,6 +11,9 @@ for PLATFORM in $PLATFORMS; do
   ARGS+="--platform ${PLATFORM} "
 done
 
+# https://issues.redhat.com/browse/RHEL-65521
+ARGS+="--exclude-crate-path idna#tests"
+
 # Clean vendor dir or the filterer will refuse to do the job
 rm -rf vendor
 


### PR DESCRIPTION
I imagine we could get rid of all the tests/ directories in every create but for now, this addresses rpmlint in centos/rhel. See https://artifacts.osci.redhat.com/testing-farm/935ce55a-9d6d-4d11-be0a-7a0babd942b7/work-rpminspect20if1pvh/rpminspect/execute/data/guest/default-0/rpminspect-1/data/viewer.html#unicode We usually waived this kind of errors in the past but this is a good time and easy patch to fix it.