### PR TITLE
chore(.packit.yaml): allow committers to dist-git to trigger koji/bodhi

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -81,12 +81,14 @@ jobs:
 
     - job: koji_build
       trigger: commit
+      allowed_pr_authors: [all_committers]
       dist_git_branches:
         - fedora-development
         - fedora-latest-stable
 
     - job: bodhi_update
       trigger: commit
+      allowed_builders: [all_committers]
       dist_git_branches:
         - fedora-development
         - fedora-latest-stable


### PR DESCRIPTION
When somebody runs `packit propose-downstream` from the CLI, the MRs to update the spec are made by the user itself and not `packit`. When we merge these MRs, koji and bodhi won't run automatically unless we set allowed_builders/allowed_pr_authors, which this patch does.