### PR TITLE
feat: add import/export API and cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,9 +408,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cbindgen"
@@ -1158,6 +1158,7 @@ name = "fdo-owner-onboarding-server"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "bytes",
  "config",
  "fdo-data-formats",
  "fdo-http-wrapper",

--- a/manufacturing-server/src/handlers/mgmt.rs
+++ b/manufacturing-server/src/handlers/mgmt.rs
@@ -1,0 +1,85 @@
+use std::fs::File;
+
+use fdo_data_formats::types::Guid;
+
+use std::io::prelude::*;
+use std::io::Read;
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct HandleOVFailure(anyhow::Error);
+impl warp::reject::Reject for HandleOVFailure {}
+
+pub(crate) async fn handler_ov(
+    guid: Guid,
+    udt: crate::ManufacturingServiceUDT,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let ov_opt = udt
+        .ownership_voucher_store
+        .load_data(&guid)
+        .await
+        .map_err(|e| warp::reject::custom(HandleOVFailure(e.into())))?;
+    if ov_opt.is_none() {
+        return Err(warp::reject::not_found());
+    }
+    let ov_pem = ov_opt
+        .unwrap()
+        .to_pem()
+        .map_err(|e| warp::reject::custom(HandleOVFailure(e.into())))?;
+    Ok(warp::reply::with_header(
+        ov_pem,
+        "Content-Type",
+        warp::http::header::HeaderValue::from_static("application/x-pem-file"),
+    ))
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct ExportFailure(anyhow::Error);
+impl warp::reject::Reject for ExportFailure {}
+
+pub(crate) async fn handler_export(
+    udt: crate::ManufacturingServiceUDT,
+) -> Result<impl warp::Reply, warp::Rejection> {
+    let ovs = udt
+        .ownership_voucher_store
+        .load_all_data()
+        .await
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    if ovs.is_empty() {
+        return Err(warp::reject::not_found());
+    }
+    let tmp_dir = tempfile::tempdir_in("manufacturer-server-ovs")
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    for ov in ovs {
+        let file_path = tmp_dir.path().join(ov.header().guid().to_string());
+        let mut tmp_file =
+            File::create(file_path).map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+        tmp_file
+            .write_all(
+                ov.to_pem()
+                    .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?
+                    .as_bytes(),
+            )
+            .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    }
+    let tmp_dir_archive = tempfile::tempdir_in("manufacturer-server-ovs-archive")
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    let tar_gz = File::create(tmp_dir_archive.path().join("ovs.tar.gz"))
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    let mut tar = tar::Builder::new(tar_gz);
+    tar.append_dir_all(".", tmp_dir)
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    tar.finish()
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    let mut file = File::open(tmp_dir_archive.path().join("ovs.tar.gz"))
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    let mut data: Vec<u8> = Vec::new();
+    file.read_to_end(&mut data)
+        .map_err(|e| warp::reject::custom(ExportFailure(e.into())))?;
+    Ok(warp::reply::with_header(
+        data,
+        "Content-Type",
+        warp::http::header::HeaderValue::from_static("application/x-tar"),
+    ))
+}

--- a/manufacturing-server/src/handlers/mod.rs
+++ b/manufacturing-server/src/handlers/mod.rs
@@ -1,2 +1,3 @@
 pub(super) mod di;
 pub(super) mod diun;
+pub(super) mod mgmt;

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
+bytes = "1.8.0"
 
 fdo-data-formats = { path = "../data-formats", version = "0.5.2" }
 fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.2", features = ["server", "client"] }


### PR DESCRIPTION
Allows exporting either a single or all the manufacturing vouchers via HTTP and importing the vouchers into the owner store. The cli commands in the owner-tool have been enhanced to support this too.