### PR TITLE
chore: allow libcryptsetup-rs >= 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,9 +1974,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libcryptsetup-rs"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5083eeb8843b0295aba9a3ddda83b35097bc0f367cb6d9db793a1435e3eee6c"
+checksum = "186b5b6114517ab1d6e25741c6fb21060aae750e70868842efc9dd1efd08baa1"
 dependencies = [
  "bitflags 2.5.0",
  "either",

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.8.4"
 nix = "0.26"
 uuid = "1.3"
 thiserror = "1"
-libcryptsetup-rs = { version = "0.11.2", features = ["mutex"] }
+libcryptsetup-rs = { version = ">= 0.11.2", features = ["mutex"] }
 secrecy = "0.8"
 devicemapper = "0.34"
 openssl = "0.10.70"


### PR DESCRIPTION
Signed-off-by: Miguel Martín <mmartinv@redhat.com>
