### PR TITLE
fix: packit: bring back pkg_tool centpkg

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,6 +28,7 @@ packages:
   fido-device-onboard-centos:
     downstream_package_name: fido-device-onboard
     upstream_package_name: fido-device-onboard
+    pkg_tool: centpkg
 
 actions:
     pre-sync:


### PR DESCRIPTION
Needed by the packit cli when we run propose-downstram