### PR TITLE
Makefile tarball targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,11 +31,12 @@ packages:
     pkg_tool: centpkg
 
 actions:
-    pre-sync:
-        - bash -c "make vendor VERSION=${PACKIT_PROJECT_VERSION}"
-        - bash -c "git restore Cargo.lock"
-    create-archive:
-        - bash -c "make packit-create-archive VERSION=${PACKIT_PROJECT_VERSION}"
+  # for the propose-downstream CLI command
+  pre-sync:
+    - bash -c "make vendor-tarball VERSION=${PACKIT_PROJECT_VERSION}"
+  # for the srpm and copr builds
+  create-archive:
+    - bash -c "make packit-create-archive VERSION=${PACKIT_PROJECT_VERSION}"
 
 jobs:
 


### PR DESCRIPTION
* Add two new `source-tarball` and `vendor-tarball` targets to generate the corresponding tarballs.
* Use the `vendor` target just to generate the filtered vendor directory and configure the cargo builds accordingly.
* Chain all the bash commands in the `vendor` target so all the bash variables contain the expected values.
* Adjust packit configuration to use the new `vendor-tarball`
