### PR TITLE
chore: prepare 0.5.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdo-admin-tool"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-client-linuxapp"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "devicemapper",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "assert-str",
  "cbindgen",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-data-formats"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "byteorder",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-db"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "diesel",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-http-wrapper"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "aws-nitro-enclaves-cose",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-manufacturing-server"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1159,7 +1159,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-onboarding-server"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1182,7 +1182,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-owner-tool"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-rendezvous-server"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-serviceinfo-api-server"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-store"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "fdo-util"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "config",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "fdo-data-formats",

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-admin-tool"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -21,10 +21,10 @@ pretty_env_logger = "0.5"
 nix = "0.26"
 tokio = { version = "1", features = ["full"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.5.3", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.5.4", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.5.4" }
 clap_builder = "4.4"
 
 [dev-dependencies]

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-client-linuxapp"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,6 +21,6 @@ secrecy = "0.8"
 devicemapper = "0.34"
 openssl = "0.10.70"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["client"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["client"] }
+fdo-util = { path = "../util", version = "0.5.4" }

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data-formats"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-db"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 
 
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 diesel = { version = "2.2.7", features = ["sqlite", "postgres", "r2d2"] }
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
 
 [dev-dependencies]
 fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.2", features = ["server"] }

--- a/fido-device-onboard.spec
+++ b/fido-device-onboard.spec
@@ -3,7 +3,7 @@
 %global combined_license Apache-2.0 AND (Apache-2.0 OR BSL-1.0) AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR MIT) AND ((Apache-2.0 OR MIT) AND BSD-3-Clause) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND BSD-2-Clause AND BSD-3-Clause AND (CC0-1.0 OR Apache-2.0) AND (CC0-1.0 OR MIT-0 OR Apache-2.0) AND ISC AND MIT AND ((MIT OR Apache-2.0) AND Unicode-DFS-2016) AND (Apache-2.0 OR MIT OR Zlib) AND MPL-2.0 AND (Unlicense OR MIT)
 
 Name:           fido-device-onboard
-Version:        0.5.3
+Version:        0.5.4
 Release:        1%{?dist}
 Summary:        A rust implementation of the FIDO Device Onboard Specification
 License:        BSD-3-Clause
@@ -312,6 +312,9 @@ Requires: fdo-init = %{version}-%{release}
 %systemd_postun_with_restart fdo-aio.service
 
 %changelog
+* Tue Mar 18 2025 Peter Robinson <pbrobinson@fedoraproject.org> - 0.5.4-1
+- Update to 0.5.4
+
 * Thu Jan 09 2025 Peter Robinson <pbrobinson@fedoraproject.org> - 0.5.2-1
 - Update to 0.5.2
 

--- a/http-wrapper/Cargo.toml
+++ b/http-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-http-wrapper"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -18,8 +18,8 @@ hex = "0.4"
 
 openssl = "0.10.70"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-store = { path = "../store", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-store = { path = "../store", version = "0.5.4" }
 aws-nitro-enclaves-cose = "0.5.2"
 
 # Server-side

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration-tests"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 publish = false
 

--- a/libfdo-data/Cargo.toml
+++ b/libfdo-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-data"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
 libc = "0.2"
 
 [build-dependencies]

--- a/libfdo-data/fdo_data.h
+++ b/libfdo-data/fdo_data.h
@@ -12,7 +12,7 @@
 
 #define FDO_DATA_MAJOR 0
 #define FDO_DATA_MINOR 5
-#define FDO_DATA_PATCH 3
+#define FDO_DATA_PATCH 4
 
 typedef struct FdoOwnershipVoucher FdoOwnershipVoucher;
 

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-client"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ rand = "0.8.4"
 tss-esapi = { version = "7.4", features = ["generate-bindings"] }
 regex = "1.3.7"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["client"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["client"] }
+fdo-util = { path = "../util", version = "0.5.4" }
 clap_builder = "4.4"

--- a/manufacturing-server/Cargo.toml
+++ b/manufacturing-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-manufacturing-server"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ tar = "0.4.41"
 flate2 = "1.0.31"
 tempfile = "3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server"] }
-fdo-store = { path = "../store", version = "0.5.3", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server"] }
+fdo-store = { path = "../store", version = "0.5.4", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.5.4" }

--- a/owner-onboarding-server/Cargo.toml
+++ b/owner-onboarding-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-onboarding-server"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_yaml = "0.9"
 time = "0.3"
 hex = "0.4"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server", "client"] }
-fdo-store = { path = "../store", version = "0.5.3", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server", "client"] }
+fdo-store = { path = "../store", version = "0.5.4", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.5.4" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-owner-tool"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,10 +17,10 @@ tokio = { version = "1", features = ["full"] }
 tss-esapi = { version = "7.4", features = ["generate-bindings"] }
 reqwest = { version = "0.12.9", features = ["blocking"] }
 
-fdo-util = { path = "../util", version = "0.5.3" }
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["client"] }
-fdo-db = { path = "../db", version = "0.5.3"}
+fdo-util = { path = "../util", version = "0.5.4" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["client"] }
+fdo-db = { path = "../db", version = "0.5.4"}
 
 hex = "0.4"
 clap_builder = "4.4"

--- a/rendezvous-server/Cargo.toml
+++ b/rendezvous-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-rendezvous-server"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ warp = "0.3.6"
 log = "0.4"
 time = "0.3"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server"] }
-fdo-store = { path = "../store", version = "0.5.3" }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server"] }
+fdo-store = { path = "../store", version = "0.5.4" }
+fdo-util = { path = "../util", version = "0.5.4" }

--- a/serviceinfo-api-server/Cargo.toml
+++ b/serviceinfo-api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-serviceinfo-api-server"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -16,7 +16,7 @@ serde = "1"
 serde_bytes = "0.11"
 serde_json = "1"
 
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server"] }
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-store = { path = "../store", version = "0.5.3", features = ["directory"] }
-fdo-util = { path = "../util", version = "0.5.3" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server"] }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-store = { path = "../store", version = "0.5.4", features = ["directory"] }
+fdo-util = { path = "../util", version = "0.5.4" }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-store"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = { version = "1", optional = true}
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
 
 thiserror = "1"
 async-trait = "0.1"
@@ -23,7 +23,7 @@ xattr = { version = "1.0", default-features = false, optional = true }  # We *ne
 serde_cbor = { version = "0.11", optional = true }
 
 # database
-fdo-db = { path = "../db", version = "0.5.3"}
+fdo-db = { path = "../db", version = "0.5.4"}
 
 diesel = { version = "2.2.7", features = ["sqlite", "postgres", "r2d2"], optional = true }
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdo-util"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Antonio Murdaca <runcom@linux.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ glob = "0.3.1"
 log = "0.4"
 serde = "1"
 
-fdo-data-formats = { path = "../data-formats", version = "0.5.3" }
-fdo-store = { path = "../store", version = "0.5.3" }
-fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.3", features = ["server", "client"] }
+fdo-data-formats = { path = "../data-formats", version = "0.5.4" }
+fdo-store = { path = "../store", version = "0.5.4" }
+fdo-http-wrapper = { path = "../http-wrapper", version = "0.5.4", features = ["server", "client"] }
 serde_yaml = "0.9"
 serde_cbor = "0.11"
 serde_json = "1"


### PR DESCRIPTION
Bump versions for the 0.5.4 release, fix spec changelog.

I think this align with Fedora to fix the FTBFS with the various versions and bumps for CVEs