### PR TITLE
fix: replace default.target with initrd.target

### DIFF
--- a/dracut/52fdo/module-setup.sh
+++ b/dracut/52fdo/module-setup.sh
@@ -19,5 +19,5 @@ install() {
         "/usr/libexec/manufacturing-client-service"
 
     install_and_enable_unit "manufacturing-client.service" \
-        "default.target"
+        "initrd.target"
 }


### PR DESCRIPTION
`default.target` is not present in c10s, RHEL10, and Fedora 42 initrd so it breaks the initramfs build.

Fixes #761 