### PR TITLE
ci: add Image Mode test automation without Packit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 on:
-  push:
-    branches:
-    - main
-  pull_request:
+#   push:
+#     branches:
+#     - main
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 name: Continuous integration
 
@@ -199,3 +200,58 @@ jobs:
           docker exec --user root tests cargo test -- --ignored
           docker stop tests
           docker rm tests
+
+#   check-pull-request:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Query author repository permissions
+#         uses: octokit/request-action@v2.x
+#         id: user_permission
+#         with:
+#           route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# 
+#       - name: Check if user does have correct permissions
+#         if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
+#         id: check_user_perm
+#         run: |
+#           echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+#           echo "allowed_user=true" >> $GITHUB_OUTPUT
+# 
+#       - name: Get information for pull request
+#         uses: octokit/request-action@v2.x
+#         id: pr-api
+#         with:
+#           route: GET /repos/${{ github.repository }}/pulls/${{ github.event.number }}
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# 
+#     outputs:
+#       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
+#       sha: ${{ fromJson(steps.pr-api.outputs.data).head.sha }}
+#       ref: ${{ fromJson(steps.pr-api.outputs.data).head.ref }}
+#       repo_url: ${{ fromJson(steps.pr-api.outputs.data).head.repo.html_url }}
+
+  RHEL-10-fdo-bootc:
+    name: Test fdo RHEL-10.0 Image Mode
+    needs: check-pull-request
+    if: ${{ needs.check-pull-request.outputs.allowed_user == 'true' }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+       - name: Run the tests
+         uses: sclorg/testing-farm-as-github-action@v3.1.2
+         with:
+           compose: RHEL-10.0-Nightly
+           api_key: ${{ secrets.TF_API_KEY }}
+           git_url: ${{ needs.check-pull-request.outputs.repo_url }}
+           git_ref: ${{ needs.check-pull-request.outputs.ref }}
+           tmt_context: "arch=x86_64;distro=rhel-10-0"
+           tmt_path: "./test/fmf"
+           tmt_plan_regex: fdo-bootc
+           tf_scope: private
+           variables: "ARCH=x86_64"
+           timeout: 90
+           secrets: "QUAY_USERNAME=${{ secrets.QUAY_USERNAME }};QUAY_PASSWORD=${{ secrets.QUAY_PASSWORD }};STAGE_REDHAT_IO_USERNAME=${{ secrets.STAGE_REDHAT_IO_USERNAME }};STAGE_REDHAT_IO_TOKEN=${{ secrets.STAGE_REDHAT_IO_TOKEN }};DOWNLOAD_NODE=${{ secrets.DOWNLOAD_NODE }};REDHAT_IO_USERNAME=${{ secrets.REDHAT_IO_USERNAME }};REDHAT_IO_TOKEN=${{ secrets.REDHAT_IO_TOKEN }}"

--- a/test/fmf/plans/image-mode-onboarding.fmf
+++ b/test/fmf/plans/image-mode-onboarding.fmf
@@ -1,0 +1,18 @@
+summary: FDO Image Mode test plan
+discover:
+  how: fmf
+  test: image-mode-onboarding
+execute:
+  how: tmt
+provision:
+  hardware:
+    virtualization:
+      is-supported: true
+    cpu:
+      processors: ">= 2"
+    memory: ">= 6 GB"
+
+/fdo-bootc:
+  summary: Test fdo in rhel-10 Image Mode
+  environment+:
+    TEST_CASE: fdo-bootc

--- a/test/fmf/tests/check-fido-device-onboard.yaml
+++ b/test/fmf/tests/check-fido-device-onboard.yaml
@@ -1,0 +1,75 @@
+---
+- hosts: image_mode_guest
+  become: no
+  vars:
+    fdo_credential: "false"
+    total_counter: "0"
+    failed_counter: "0"
+
+  tasks:
+    # check installed fido device onboard packages
+    - name: fdo should be installed
+      block:
+        - name: fdo should be installed
+          shell: rpm -qa | grep -E 'fdo|fido'
+
+    # check tpm device
+    - name: check tpm device
+      stat:
+        path: /dev/tpm0
+      ignore_errors: yes
+      when: fdo_credential == "true"
+
+    # case: check fdo onboarding status
+    # after fdo onboarding finished, /boot/device-credentials will be moved to /etc/device-credentials
+    - name: check if fdo onboarding completed successfully
+      block:
+        - name: wait until the file /etc/device-credentials is present before continuing
+          wait_for:
+            path: /etc/device-credentials
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: fdo_credential == "true"
+
+    # Check FDO status and task status
+    - name: check fdo-client-linuxapp logs
+      command: journalctl -u fdo-client-linuxapp
+      register: result_fdo_client_linuxapp_journalctl
+      become: yes
+      when:
+        - fdo_credential == "true"
+
+    - name: make sure secure device onboarding has been done successfully
+      block:
+        - assert:
+            that:
+              - "'Secure Device Onboarding DONE' in result_fdo_client_linuxapp_journalctl.stdout"
+            fail_msg: "Secure Device Onboarding not successful"
+            success_msg: "Secure Device Onboarding successful"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: fdo_credential == "true"
+
+    # Check FDO client avc log
+    - name: check FDO client avc logs
+      command: ausearch -m avc -m user_avc -m selinux_err -i
+      ignore_errors: yes
+      become: yes
+      when:
+        - fdo_credential == "true"
+
+    - assert:
+        that:
+          - failed_counter == "0"
+        fail_msg: "Run {{ total_counter }} tests, but {{ failed_counter }} of them failed"
+        success_msg: "Totally {{ total_counter }} test passed"

--- a/test/fmf/tests/fdo-bootc.sh
+++ b/test/fmf/tests/fdo-bootc.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+set -euox pipefail
+
+# FDO test in RHEL-10 Image Mode
+
+# Local variables
+VM_NAME="fdo-disk-image"
+GUEST_ADDRESS=192.168.100.50
+SSH_USER="admin"
+
+# Set up temporary files.
+TEMPDIR=$(mktemp -d)
+
+# SSH setup.
+SSH_OPTIONS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5)
+SSH_KEY=rhel-edge/key/ostree_key
+EDGE_USER_PASSWORD=foobar
+
+function clean_up {
+    greenprint "🧼 Cleaning up"
+    sudo rm -rf ./{Containerfile,output,config.toml}
+    sudo podman logout registry.stage.redhat.io
+    sudo podman rmi -a -f
+    sudo rm -rf /var/lib/libvirt/images/{fdo-iso.qcow2,install.iso}
+    sudo virsh net-destroy integration && sudo virsh net-undefine integration
+    VM_STATUS=$(sudo virsh list --all | awk '{print $3}' | tail -n 2)
+    if [[ $VM_STATUS == running ]]; then
+        sudo virsh destroy "${VM_NAME}"
+    fi
+    sudo virsh undefine "${VM_NAME}" --nvram
+    # TO DO: Remove tag from quay.io registry
+    # skopeo delete --creds "${QUAY_USERNAME}:${QUAY_PASSWORD}" "${QUAY_REPO_URL}:${QUAY_REPO_TAG}"
+}
+
+# Colorful output.
+function greenprint {
+    echo -e "\033[1;32m${1}\033[0m"
+}
+
+wait_for_ssh_up () {
+    SSH_STATUS=$(sudo ssh "${SSH_OPTIONS[@]}" -i "${SSH_KEY}" "${SSH_USER}@${1}" '/bin/bash -c "echo -n READY"')
+    if [[ $SSH_STATUS == READY ]]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+check_result () {
+    greenprint "🎏 Checking for test result"
+    if [[ $RESULTS == 1 ]]; then
+        greenprint "💚 Success"
+    else
+        greenprint "❌ Failed"
+        clean_up
+        exit 1
+    fi
+}
+
+trap clean_up EXIT
+
+sudo dnf install -y \
+    cargo \
+    openssl \
+    openssl-devel \
+    git \
+    make \
+    systemd \
+    krb5-devel \
+    python3-docutils \
+    gpgme-devel \
+    libassuan-devel \
+    systemd-rpm-macros \
+    rpmdevtools \
+    golang \
+    go-rpm-macros \
+    python3-devel \
+    selinux-policy-devel \
+    device-mapper-devel \
+    podman \
+    qemu-img \
+    qemu-kvm \
+    libvirt-client \
+    libvirt-daemon-kvm \
+    libvirt-daemon \
+    virt-install
+
+# Clone upstream repo and build fdo packages
+git clone https://github.com/fdo-rs/fido-device-onboard-rs.git && cd fido-device-onboard-rs
+make rpm
+sudo dnf -y install rpmbuild/RPMS/x86_64/*
+cd ..
+
+# Manufacturing server setup
+# Clone downstream repo custom branch (fdo simplified installer setup skipping disk encryption)
+git clone -b fdo-man-server-infra https://github.com/mcattamoredhat/rhel-edge.git && cd rhel-edge
+DOWNLOAD_NODE="${DOWNLOAD_NODE}" ./ostree-simplified-installer.sh
+cd ..
+
+# Login to Stage registry
+sudo podman login -u "${STAGE_REDHAT_IO_USERNAME}" -p "${STAGE_REDHAT_IO_TOKEN}" registry.stage.redhat.io
+
+# Register the system to be able to install missing packages
+sudo subscription-manager register --username "${REDHAT_IO_USERNAME}" --password "${REDHAT_IO_TOKEN}"
+
+# Prepare Containerfile
+tee Containerfile > /dev/null << STOPHERE
+FROM registry.stage.redhat.io/rhel10/rhel-bootc:10.0
+RUN echo 'root' | passwd --stdin root
+
+# Copy the local RPM files into the container
+COPY fido-device-onboard-rs/rpmbuild/RPMS/x86_64/* /tmp/
+
+# Install packages
+RUN dnf install -y \
+    /tmp/fido-device-onboard-debuginfo-*.el10.x86_64.rpm \
+    /tmp/fido-device-onboard-debugsource-*.el10.x86_64.rpm \
+    /tmp/fdo-init-debuginfo-*.el10.x86_64.rpm \
+    /tmp/fdo-init-*.el10.x86_64.rpm \
+    /tmp/fdo-client-debuginfo-*.el10.x86_64.rpm \
+    /tmp/fdo-client-*.el10.x86_64.rpm \
+    clevis \
+    clevis-dracut \
+    clevis-luks \
+    clevis-pin-tpm2 \
+    clevis-systemd
+
+RUN systemctl enable fdo-client-linuxapp.service
+STOPHERE
+
+# Create container image
+sudo podman build -f Containerfile -t quay.io/"${QUAY_USERNAME}"/test-repository/rhel10-bootc:latest
+
+# Push to quay.io
+sudo podman push rhel10-bootc --creds="${QUAY_USERNAME}":"${QUAY_PASSWORD}" quay.io/"${QUAY_USERNAME}"/test-repository/rhel10-bootc:latest
+
+mkdir -pv output
+
+# Create config.toml with kickstart information
+tee config.toml > /dev/null << STOPHERE
+[customizations.installer.kickstart]
+contents = """
+text
+lang en_US.UTF-8
+keyboard us
+timezone --utc Etc/UTC
+selinux --enforcing
+rootpw --plaintext root
+user --name=admin --groups=wheel --iscrypted --password=\$6\$1LgwKw9aOoAi/Zy9\$Pn3ErY1E8/yEanJ98evqKEW.DZp24HTuqXPJl6GYCm8uuobAmwxLv7rGCvTRZhxtcYdmC0.XnYRSR9Sh6de3p0
+sshkey --username=admin "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCzxo5dEcS+LDK/OFAfHo6740EyoDM8aYaCkBala0FnWfMMTOq7PQe04ahB0eFLS3IlQtK5bpgzxBdFGVqF6uT5z4hhaPjQec0G3+BD5Pxo6V+SxShKZo+ZNGU3HVrF9p2V7QH0YFQj5B8F6AicA3fYh2BVUFECTPuMpy5A52ufWu0r4xOFmbU7SIhRQRAQz2u4yjXqBsrpYptAvyzzoN4gjUhNnwOHSPsvFpWoBFkWmqn0ytgHg3Vv9DlHW+45P02QH1UFedXR2MqLnwRI30qqtaOkVS+9rE/dhnR+XPpHHG+hv2TgMDAuQ3IK7Ab5m/yCbN73cxFifH4LST0vVG3Jx45xn+GTeHHhfkAfBSCtya6191jixbqyovpRunCBKexI5cfRPtWOitM3m7Mq26r7LpobMM+oOLUm4p0KKNIthWcmK9tYwXWSuGGfUQ+Y8gt7E0G06ZGbCPHOrxJ8lYQqXsif04piONPA/c9Hq43O99KPNGShONCS9oPFdOLRT3U= ostree-image-test"
+bootloader --timeout=1 --append="net.ifnames=0 modprobe.blacklist=vc4"
+network --bootproto=dhcp --device=link --activate --onboot=on
+zerombr
+clearpart --all --initlabel --disklabel=msdos
+autopart --nohome --noswap --type=plain
+poweroff
+%post --log=/var/log/anaconda/post-install.log --erroronfail
+export MANUFACTURING_SERVER_URL="http://192.168.100.1:8080"
+export DIUN_PUB_KEY_INSECURE="true"
+/usr/libexec/fdo/fdo-manufacturing-client
+# no sudo password for SSH user
+echo -e 'admin\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# Remove any persistent NIC rules generated by udev
+rm -vf /etc/udev/rules.d/*persistent-net*.rules
+# And ensure that we will do DHCP on eth0 on startup
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+echo "Packages within this iot or edge image:"
+echo "-----------------------------------------------------------------------"
+rpm -qa | sort
+echo "-----------------------------------------------------------------------"
+# Note that running rpm recreates the rpm db files which aren't needed/wanted
+rm -f /var/lib/rpm/__db*
+echo "Zeroing out empty space."
+# This forces the filesystem to reclaim space from deleted files
+dd bs=1M if=/dev/zero of=/var/tmp/zeros || :
+rm -f /var/tmp/zeros
+echo "(Don't worry -- that out-of-space error was expected.)"
+%end
+"""
+STOPHERE
+
+# Ensure the image has been fetched
+sudo podman pull --creds="${QUAY_USERNAME}":"${QUAY_PASSWORD}" quay.io/"${QUAY_USERNAME}"/test-repository/rhel10-bootc
+
+# Generate disk image using bib
+sudo podman run \
+    --rm \
+    -it \
+    --privileged \
+    --pull=newer \
+    --security-opt label=type:unconfined_t \
+    -v $(pwd)/config.toml:/config.toml:ro \
+    -v $(pwd)/output:/output \
+    -v /var/lib/containers/storage:/var/lib/containers/storage \
+    registry.stage.redhat.io/rhel10/bootc-image-builder:10.0 \
+    --type iso \
+    --local \
+    --config /config.toml \
+    quay.io/"${QUAY_USERNAME}"/test-repository/rhel10-bootc
+
+sudo qemu-img create -f qcow2 /var/lib/libvirt/images/fdo-iso.qcow2 20G
+sudo cp output/bootiso/install.iso /var/lib/libvirt/images/
+sudo restorecon -Rv /var/lib/libvirt/images/
+sudo virt-install  --name="${VM_NAME}" \
+                --disk path=/var/lib/libvirt/images/fdo-iso.qcow2,format=qcow2 \
+                --ram 3072 \
+                --vcpus 2 \
+                --network network=integration,mac=34:49:22:B0:83:30 \
+                --os-type linux \
+                --os-variant rhel10-unknown \
+                --cdrom /var/lib/libvirt/images/install.iso \
+                --boot uefi \
+                --tpm backend.type=emulator,backend.version=2.0,model=tpm-crb \
+                --nographics \
+                --noautoconsole \
+                --wait=-1 \
+                --noreboot
+
+# Start VM.
+greenprint "Start VM"
+sudo virsh start "${VM_NAME}"
+
+# Check for ssh ready to go.
+greenprint "🛃 Checking for SSH is ready to go"
+for _ in $(seq 0 30); do
+    RESULTS="$(wait_for_ssh_up $GUEST_ADDRESS)"
+    if [[ $RESULTS == 1 ]]; then
+        echo "SSH is ready now! 🥳"
+        break
+    fi
+    sleep 10
+done
+
+# Check image installation result
+check_result
+
+# Add instance IP address into /etc/ansible/hosts
+tee "${TEMPDIR}"/inventory > /dev/null << EOF
+[image_mode_guest]
+${GUEST_ADDRESS}
+
+[image_mode_guest:vars]
+ansible_python_interpreter=/usr/bin/python3
+ansible_user=${SSH_USER}
+ansible_private_key_file=${SSH_KEY}
+ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+ansible_become=yes
+ansible_become_method=sudo
+ansible_become_pass=${EDGE_USER_PASSWORD}
+EOF
+
+# Test IoT/Edge OS
+podman run --network=host --annotation run.oci.keep_original_groups=1 -v "$(pwd)":/work:z -v "${TEMPDIR}":/tmp:z --rm quay.io/rhel-edge/ansible-runner:latest ansible-playbook -v -i /tmp/inventory -e fdo_credential="true" check-fido-device-onboard.yaml || RESULTS=0
+
+# Check test result
+check_result
+
+exit 0

--- a/test/fmf/tests/image-mode-onboarding.fmf
+++ b/test/fmf/tests/image-mode-onboarding.fmf
@@ -1,0 +1,6 @@
+test: ./test.sh
+duration: 120m
+adjust+:
+  - when: distro != rhel
+    enabled: false
+    because: Test enabled just for Image Mode RHEL-10

--- a/test/fmf/tests/test.sh
+++ b/test/fmf/tests/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euox pipefail
+
+function run_tests() {
+	if [ "$TEST_CASE" = "fdo-bootc" ]; then
+		./fdo-bootc.sh
+	else
+		echo "Error: Test case $TEST_CASE not found!"
+		exit 1
+	fi
+}
+
+run_tests
+exit 0


### PR DESCRIPTION
This is an approach to add Image Mode RHEL-10 ci tests without using Packit, and making rpm packages within the testing farm spawned VM instead.

The reason to proceed without Packit is to circumvent the difficulty of handling environment secrets, that implies encrypting needed secrets in every fork that opens a pull request against upstream repository.