### PR TITLE
chore: bump tss-esapi crate to 7.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,9 +3543,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tss-esapi"
-version = "7.5.1"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ba6594ded739cb539f8ffcd3713f6c21d4525c47314bbc6de15c0cd251aedf"
+checksum = "78ea9ccde878b029392ac97b5be1f470173d06ea41d18ad0bb3c92794c16a0f2"
 dependencies = [
  "bitfield",
  "enumflags2",

--- a/data-formats/Cargo.toml
+++ b/data-formats/Cargo.toml
@@ -23,7 +23,7 @@ num-traits = "0.2"
 num-derive = "0.4"
 paste = "1.0"
 pem = "3.0"
-tss-esapi = { version = "7.4", features = ["generate-bindings"] }
+tss-esapi = { version = "7.6", features = ["generate-bindings"] }
 byteorder = "1"
 
 http = "0.2"

--- a/manufacturing-client/Cargo.toml
+++ b/manufacturing-client/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4"
 openssl = "0.10.72"
 tokio = { version = "1", features = ["full"] }
 rand = "0.8.4"
-tss-esapi = { version = "7.4", features = ["generate-bindings"] }
+tss-esapi = { version = "7.6", features = ["generate-bindings"] }
 regex = "1.11.1"
 
 fdo-data-formats = { path = "../data-formats", version = "0.5.4" }

--- a/owner-tool/Cargo.toml
+++ b/owner-tool/Cargo.toml
@@ -14,7 +14,7 @@ openssl = "0.10.72"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
-tss-esapi = { version = "7.4", features = ["generate-bindings"] }
+tss-esapi = { version = "7.6", features = ["generate-bindings"] }
 reqwest = { version = "0.12.9", features = ["blocking"] }
 
 fdo-util = { path = "../util", version = "0.5.4" }


### PR DESCRIPTION
Bump the TPM2 tss-esapi crate to the latest minor rev for some small fixes.