### PR TITLE
chore: fix the container deps

### DIFF
--- a/contrib/containers/admin-cli
+++ b/contrib/containers/admin-cli
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream9
 ARG BUILDID
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-admin-tool /usr/local/bin
-RUN yum install -y sqlite sqlite-devel libpq libpq-devel
+RUN yum install -y sqlite libpq
 ENTRYPOINT ["fdo-admin-tool"]

--- a/contrib/containers/aio
+++ b/contrib/containers/aio
@@ -8,4 +8,5 @@ COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-serviceinfo-api-ser
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-client-linuxapp /usr/bin
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-owner-tool /usr/bin
 COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-manufacturing-client /usr/bin
+RUN yum install -y sqlite libpq cryptsetup-libs clevis clevis-luks
 ENTRYPOINT ["fdo-admin-tool"]

--- a/contrib/containers/manufacturing-server
+++ b/contrib/containers/manufacturing-server
@@ -4,6 +4,6 @@ COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-manufacturing-serve
 RUN mkdir -p /etc/fdo/sessions
 RUN mkdir -p /etc/fdo/keys
 RUN mkdir -p /etc/fdo/manufacturing-server.conf.d
-RUN yum install -y sqlite sqlite-devel libpq libpq-devel
+RUN yum install -y sqlite libpq
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-manufacturing-server"]

--- a/contrib/containers/owner-onboarding-server
+++ b/contrib/containers/owner-onboarding-server
@@ -4,6 +4,6 @@ COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-owner-onboarding-se
 RUN mkdir -p /etc/fdo/sessions
 RUN mkdir -p /etc/fdo/keys
 RUN mkdir -p /etc/fdo/owner-onboarding-server.conf.d
-RUN yum install -y sqlite sqlite-devel libpq libpq-devel
+RUN yum install -y sqlite libpq
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-owner-onboarding-server"]

--- a/contrib/containers/rendezvous-server
+++ b/contrib/containers/rendezvous-server
@@ -4,6 +4,6 @@ COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-rendezvous-server /
 RUN mkdir -p /etc/fdo/sessions
 RUN mkdir -p /etc/fdo/keys 
 RUN mkdir -p /etc/fdo/rendezvous-server.conf.d
-RUN yum install -y sqlite sqlite-devel libpq libpq-devel
+RUN yum install -y sqlite libpq
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-rendezvous-server"]

--- a/contrib/containers/serviceinfo-api-server
+++ b/contrib/containers/serviceinfo-api-server
@@ -4,6 +4,6 @@ COPY --from=fdo-build:${BUILDID} /usr/src/target/release/fdo-serviceinfo-api-ser
 RUN mkdir -p /etc/fdo/sessions
 RUN mkdir -p /etc/fdo/device_specific_serviceinfo
 RUN mkdir -p /etc/fdo/serviceinfo-api-server.conf.d
-RUN yum install -y sqlite sqlite-devel libpq libpq-devel
+RUN yum install -y sqlite libpq
 ENV LOG_LEVEL=trace
 ENTRYPOINT ["fdo-serviceinfo-api-server"]


### PR DESCRIPTION
The aio (All In One) container is missing the DB client libraries and the deps for the FDO client to run, while at it drop the -devel packages for the services as they only need the actual libraries to run.