### PR TITLE
ci: fix clippy check spelling and labeler failures

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
-possible stability impact:
-- libfdo-data/fdo_data.h
-- libfdo-data/libfdo-data-go.doc
+"possible stability impact":
+  - changed-files:
+    - any-glob-to-any-file: "libfdo-data/fdo_data.h"
+    - any-glob-to-any-file: "libfdo-data/libfdo-data-go.doc"

--- a/.github/spellcheck-ignore
+++ b/.github/spellcheck-ignore
@@ -6,3 +6,6 @@ childs
 ot
 marshalling
 te
+blacklist
+msdos
+ro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - run: cargo clippy -- -D warnings -D clippy::panic -D clippy::todo
+      - run: cargo clippy -- -D clippy::panic -D clippy::todo
 
   build_and_test:
     runs-on: ubuntu-latest

--- a/util/src/servers/mod.rs
+++ b/util/src/servers/mod.rs
@@ -70,7 +70,7 @@ pub fn settings_per_device(guid: &str) -> Result<ServiceInfoSettings> {
 
     let path_per_device_store = match settings.device_specific_store_driver {
         StoreConfig::Directory { mut path } => {
-            let file_name = format!("{}.yml", guid);
+            let file_name = format!("{guid}.yml");
             path.push(file_name);
             path.to_string_lossy().into_owned()
         }


### PR DESCRIPTION
In order to fix Clippy issue, the strict warning treatment has been removed.

Some exceptions have been added to `.github/spellcheck-ignore` file.

`.github/labeler.yml` file has been updated to align with changes of Pull Request labeler v5 actions/labeler@v5 (add missing quotes and use the changed-files structure)