### PR TITLE
ci: fix clippy warnings

### DIFF
--- a/manufacturing-server/src/main.rs
+++ b/manufacturing-server/src/main.rs
@@ -295,7 +295,7 @@ async fn main() -> Result<()> {
                         return Err(Rejection::from(fdo_http_wrapper::server::Error::new(
                             ErrorCode::InternalServerError,
                             fdo_data_formats::constants::MessageType::Invalid,
-                            &format!("Error loading ownership voucher with guid {}: {}", guid, e),
+                            &format!("Error loading ownership voucher with guid {guid}: {e}"),
                         )))
                     }
                 };
@@ -305,7 +305,7 @@ async fn main() -> Result<()> {
                         return Err(Rejection::from(fdo_http_wrapper::server::Error::new(
                             ErrorCode::InternalServerError,
                             fdo_data_formats::constants::MessageType::Invalid,
-                            &format!("Error converting ownership voucher to pem: {}", e),
+                            &format!("Error converting ownership voucher to pem: {e}"),
                         )))
                     }
                 };

--- a/owner-tool/src/main.rs
+++ b/owner-tool/src/main.rs
@@ -446,7 +446,7 @@ fn initialize_device(args: &InitializeDeviceArguments) -> Result<(), Error> {
     fs::write(&args.ownershipvoucher_out, ov).context("Error writing ownership voucher")?;
     fs::write(&args.device_credential_out, devcred).context("Error writing device credential")?;
 
-    println!("Created ownership voucher for device {}", device_guid);
+    println!("Created ownership voucher for device {device_guid}");
 
     Ok(())
 }

--- a/util/src/servers/mod.rs
+++ b/util/src/servers/mod.rs
@@ -70,7 +70,7 @@ pub fn settings_per_device(guid: &str) -> Result<ServiceInfoSettings> {
 
     let path_per_device_store = match settings.device_specific_store_driver {
         StoreConfig::Directory { mut path } => {
-            let file_name = format!("{}.yml", guid);
+            let file_name = format!("{guid}.yml");
             path.push(file_name);
             path.to_string_lossy().into_owned()
         }


### PR DESCRIPTION
Fix clippy warnings using Rust's more readable inlined format string syntax.