### PR TITLE
Update secrecy dependency from 0.8 to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,9 +2910,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
 ]

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -17,7 +17,7 @@ nix = "0.26"
 uuid = "1.3"
 thiserror = "1"
 libcryptsetup-rs = { version = ">= 0.11.2", features = ["mutex"] }
-secrecy = "0.8"
+secrecy = "0.10"
 devicemapper = "0.34"
 openssl = "0.10.72"
 

--- a/client-linuxapp/src/reencrypt/rebind.rs
+++ b/client-linuxapp/src/reencrypt/rebind.rs
@@ -2,7 +2,7 @@ use std::{io::Write, process::Command};
 
 use anyhow::{anyhow, bail, Context, Result};
 use libcryptsetup_rs::CryptDevice;
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 
 fn get_clevis_token(dev: &mut CryptDevice) -> Result<u32> {
     let mut clevis_token = None;
@@ -58,7 +58,7 @@ fn get_clevis_keyslot(dev: &mut CryptDevice, clevis_token: u32) -> Result<u32> {
 
 pub(super) fn get_clevis_token_slot_pass(
     dev: &mut CryptDevice,
-) -> Result<(u32, u32, Secret<Vec<u8>>)> {
+) -> Result<(u32, u32, SecretBox<Vec<u8>>)> {
     let clevis_token = get_clevis_token(dev).context("Error getting clevis token ID")?;
     let clevis_slot =
         get_clevis_keyslot(dev, clevis_token).context("error getting clevis keyslot")?;
@@ -81,7 +81,7 @@ pub(super) fn get_clevis_token_slot_pass(
         .output()
         .context("Error calling clevis to get password")?;
 
-    let pass = secrecy::Secret::new(output.stdout);
+    let pass = secrecy::SecretBox::new(Box::new(output.stdout));
 
     if !output.status.success() {
         bail!(


### PR DESCRIPTION
Looking at the [changelog for `secrecy` 0.10](https://github.com/iqlusioninc/crates/blob/70eaa76/secrecy/CHANGELOG.md#0100-2024-09-17) (there was no 0.9),

> This release represents a significant redesign of the secrecy crate. […] The most notable change is the generic Secret<T> type has been removed: instead use SecretBox<T> which stores secrets on the heap instead of the stack.

I think I’ve handled the API changes reasonably, but review is appreciated.