### PR TITLE
Update nix dependency from 0.26 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,7 +1015,7 @@ dependencies = [
  "fdo-util",
  "futures",
  "log",
- "nix 0.26.4",
+ "nix 0.31.2",
  "openssl",
  "pretty_env_logger",
  "rand",
@@ -1031,7 +1037,7 @@ dependencies = [
  "fdo-util",
  "libcryptsetup-rs",
  "log",
- "nix 0.26.4",
+ "nix 0.31.2",
  "openssl",
  "rand",
  "secrecy",
@@ -1974,9 +1980,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libcryptsetup-rs"
@@ -2080,9 +2086,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2167,19 +2173,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -2187,6 +2180,19 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if 1.0.0",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/admin-tool/Cargo.toml
+++ b/admin-tool/Cargo.toml
@@ -18,7 +18,7 @@ reqwest = "0.12"
 serde = "1"
 serde_yaml = "0.9"
 pretty_env_logger = "0.5"
-nix = "0.26"
+nix = { version = "0.31", features = ["net"] }
 tokio = { version = "1", features = ["full"] }
 
 fdo-data-formats = { path = "../data-formats", version = "0.5.5" }

--- a/client-linuxapp/Cargo.toml
+++ b/client-linuxapp/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1", features = ["full"] }
 sys-info = "0.9"
 serde_bytes = "0.11"
 rand = "0.8.4"
-nix = "0.26"
+nix = { version = "0.31", features = ["fs", "user"] }
 uuid = "1.3"
 thiserror = "1"
 libcryptsetup-rs = { version = ">= 0.11.2", features = ["mutex"] }


### PR DESCRIPTION
https://github.com/nix-rust/nix/blob/v0.31.2/CHANGELOG.md

No source-code changes appear to be required, although I did have to explicitly enable some features. I tested this by running `cargo test` in `client-linuxapp/` and in `admin-tool/`.

The motivation is that, in Fedora, we’re trying to reduce dependencies on our `rust-nix0.26` compat package, for reasons described in the [downstream issue](https://forge.fedoraproject.org/rust/backlog/issues/7), and it’s our policy to [offer such changes upstream](https://docs.fedoraproject.org/en-US/package-maintainers/Staying_Close_to_Upstream_Projects).