### PR TITLE
fix(.packit.yaml): use explicit distros mapping for CentOS Stream tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -94,10 +94,16 @@ jobs:
     owner: "@fedora-iot"
     project: fedora-iot
 
+  # Use dict format with explicit distros to work around
+  # https://github.com/packit/packit/issues/2700
   - job: tests
     trigger: pull_request
     identifier: onboarding-centos
     fmf_path: test/fmf
     tmt_plan: plans/onboarding
     packages: [fido-device-onboard-centos]
-    targets: ["centos-stream-9", "centos-stream-10"]
+    targets:
+      centos-stream-9-x86_64:
+        distros: [centos-stream-9]
+      centos-stream-10-x86_64:
+        distros: [centos-stream-10]


### PR DESCRIPTION
Use dict format with explicit distros in the tests job to prevent
packit from incorrectly mapping centos-stream targets to epel chroots.

Workaround for https://github.com/packit/packit/issues/2700

Signed-off-by: Miguel Martín <mmartinv@redhat.com>
